### PR TITLE
Adding custom properties to OpenApiSpecInputProvider

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
@@ -1,23 +1,21 @@
 package io.quarkiverse.openapi.generator.deployment;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Map;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 // This configuration is read in codegen phase (before build time), the annotation is for document purposes and avoiding quarkus warns
-@ConfigGroup
-@ConfigRoot(prefix = SpecConfig.BUILD_TIME_CONFIG_PREFIX)
+@ConfigRoot(name = SpecConfig.BUILD_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
 public class SpecConfig {
 
-    public static final String BUILD_TIME_CONFIG_PREFIX = "quarkus.openapi-generator.codegen";
+    static final String BUILD_TIME_CONFIG_PREFIX = "openapi-generator.codegen";
     public static final String API_PKG_SUFFIX = ".api";
     public static final String MODEL_PKG_SUFFIX = ".model";
     // package visibility for unit tests
-    static final String BUILD_TIME_SPEC_PREFIX_FORMAT = BUILD_TIME_CONFIG_PREFIX + ".spec.\"%s\"";
+    static final String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + BUILD_TIME_CONFIG_PREFIX + ".spec.\"%s\"";
     private static final String BASE_PACKAGE_PROP_FORMAT = "%s.base-package";
     private static final String SKIP_FORM_MODEL_PROP_FORMAT = "%s.skip-form-model";
 
@@ -25,11 +23,7 @@ public class SpecConfig {
      * OpenAPI Spec details for codegen configuration.
      */
     @ConfigItem(name = "spec")
-    Map<String, SpecItemConfig> specItem;
-
-    public Map<String, SpecItemConfig> getSpecItem() {
-        return Collections.unmodifiableMap(specItem);
-    }
+    public Map<String, SpecItemConfig> specItem;
 
     public static String resolveApiPackage(final String basePackage) {
         return String.format("%s%s", basePackage, API_PKG_SUFFIX);
@@ -39,7 +33,7 @@ public class SpecConfig {
         return String.format("%s%s", basePackage, MODEL_PKG_SUFFIX);
     }
 
-    public static String getResolvedBasePackageProperty(final Path openApiFilePath) {
+    public static String getResolvedBasePackagePropertyName(final Path openApiFilePath) {
         return String.format(BASE_PACKAGE_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -1,14 +1,24 @@
 package io.quarkiverse.openapi.generator.deployment;
 
 // Configuration class for documentation purposes
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
+@ConfigGroup
 public class SpecItemConfig {
 
     /**
      * Base package for where the generated code for the given OpenAPI specification will be added.
      */
-    @ConfigItem
-    String basePackage;
+    @ConfigItem(name = "base-package")
+    public String basePackage;
+
+    /**
+     * Whether to skip the generation of models for form parameters
+     */
+    @ConfigItem(name = "skip-form-model")
+    public Optional<Boolean> skipFormModel;
 
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/SpecInputModel.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/SpecInputModel.java
@@ -3,12 +3,21 @@ package io.quarkiverse.openapi.generator.deployment.codegen;
 import static java.util.Objects.requireNonNull;
 
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.quarkiverse.openapi.generator.deployment.SpecConfig;
+import io.smallrye.config.PropertiesConfigSource;
 
 public class SpecInputModel {
 
     private final InputStream inputStream;
     private final String filename;
+    private final Map<String, String> codegenProperties = new HashMap<>();
 
     public SpecInputModel(final String filename, final InputStream inputStream) {
         requireNonNull(inputStream, "InputStream can't be null");
@@ -17,12 +26,29 @@ public class SpecInputModel {
         this.filename = filename;
     }
 
+    /**
+     * @param filename the name of the file for reference
+     * @param inputStream the content of the spec file
+     * @param basePackageName the name of the package where the files will be generated
+     */
+    public SpecInputModel(final String filename, final InputStream inputStream, final String basePackageName) {
+        requireNonNull(inputStream, "InputStream can't be null");
+        requireNonNull(filename, "File name can't be null");
+        this.inputStream = inputStream;
+        this.filename = filename;
+        this.codegenProperties.put(SpecConfig.getResolvedBasePackagePropertyName(Path.of(filename)), basePackageName);
+    }
+
     public String getFileName() {
         return filename;
     }
 
     public InputStream getInputStream() {
         return inputStream;
+    }
+
+    public ConfigSource getConfigSource() {
+        return new PropertiesConfigSource(this.codegenProperties, "properties", 0);
     }
 
     @Override

--- a/integration-tests/generation-input/src/main/java/io/quarkiverse/openapi/generator/codegen/ClassPathPetstoreOpenApiSpecInputProvider.java
+++ b/integration-tests/generation-input/src/main/java/io/quarkiverse/openapi/generator/codegen/ClassPathPetstoreOpenApiSpecInputProvider.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.openapi.generator.codegen;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiSpecInputProvider;
@@ -16,8 +16,11 @@ public class ClassPathPetstoreOpenApiSpecInputProvider implements OpenApiSpecInp
 
     @Override
     public List<SpecInputModel> read(CodeGenContext context) {
-        return Collections.singletonList(
-                new SpecInputModel("petstore.json", this.getClass().getResourceAsStream("/specs/petstore.json")));
+        final List<SpecInputModel> inputModels = new ArrayList<>();
+        inputModels.add(new SpecInputModel("petstore.json", this.getClass().getResourceAsStream("/specs/petstore.json")));
+        inputModels.add(new SpecInputModel("subtraction.yaml", this.getClass().getResourceAsStream("/specs/subtraction.yaml"),
+                "org.math"));
+        return inputModels;
     }
 
 }

--- a/integration-tests/generation-input/src/main/resources/specs/subtraction.yaml
+++ b/integration-tests/generation-input/src/main/resources/specs/subtraction.yaml
@@ -1,0 +1,31 @@
+---
+openapi: 3.0.3
+info:
+  title: Generated API
+  version: "1.0"
+paths:
+  /:
+    post:
+      operationId: doOperation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubtractionOperation'
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    SubtractionOperation:
+      type: object
+      properties:
+        difference:
+          format: float
+          type: number
+        leftElement:
+          format: float
+          type: number
+        rightElement:
+          format: float
+          type: number

--- a/integration-tests/generation-tests/src/main/resources/application.properties
+++ b/integration-tests/generation-tests/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+quarkus.openapi-generator.codegen.spec."petstore.json".base-package=org.acme.petstore
+# This one is passed through the Classpath source provider. Uncomment to overwrite it
+#quarkus.openapi-generator.codegen.spec."subtraction.yaml".base-package=org.acme.subtraction
 quarkus.oidc-client.client-enabled=false
 # ${keycloak.url} is provided by test-utils
 # petstore_auth is the name of the security scheme from the openapi spec file (petstore.json)

--- a/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/PetStoreTest.java
+++ b/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/PetStoreTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.inject.Inject;
 
+import org.acme.petstore.api.PetApi;
+import org.acme.petstore.model.Pet;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
-import org.openapi.quarkus.api.PetApi;
-import org.openapi.quarkus.model.Pet;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 

--- a/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/WiremockPetStore.java
+++ b/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/WiremockPetStore.java
@@ -29,7 +29,7 @@ public class WiremockPetStore implements QuarkusTestResourceLifecycleManager {
                                         "\"name\": \"Bidu\"," +
                                         "\"status\": \"AVAILABLE\"" +
                                         "}")));
-        return Collections.singletonMap("org.openapi.quarkus.api.PetApi/mp-rest/url", wireMockServer.baseUrl());
+        return Collections.singletonMap("org.acme.petstore.api.PetApi/mp-rest/url", wireMockServer.baseUrl());
     }
 
     @Override


### PR DESCRIPTION
In this PR we add the possibility to configure the generated code via the `OpenApiSpecInputProvider` interface.