### PR TITLE
Standardize the openapi spec id in configs and add baseUri to the RegisterRestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To fine tune the configuration for each spec file, add the following entry to yo
 quarkus.openapi-generator.codegen.spec.petstore_json.base-package=org.acme.openapi
 ```
 
-Note that the file name is used to configure the specific information for each spec. Periods (.) are replaced by underline (_).
+Note that the file name is used to configure the specific information for each spec. We follow the [Environment Variables Mapping Rules](https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#environment-variables-mapping-rules) from Microprofile Configuration to sanitize the OpenAPI spec filename. Any non-alphabetic characters are replaced by an underscore `_`.
 
 Run `mvn compile` to generate your classes in `target/generated-sources/open-api-json` path:
 
@@ -279,7 +279,8 @@ Add the [SmallRye Fault Tolerance extension](https://quarkus.io/guides/smallrye-
 Assuming your Open API spec file is in `src/main/openapi/simple-openapi.json`, add the following configuration to your `application.properties` file:
 
 ````properties
-quarkus.openapi-generator.codegen.spec.simple-openapi_json.base-package=org.acme.openapi.simple
+# Note that the file name must have only alphabetic characters or underscores (_).
+quarkus.openapi-generator.codegen.spec.simple_openapi_json.base-package=org.acme.openapi.simple
 # Enables the CircuitBreaker extension for the byeGet method from the DefaultApi class
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 ````
@@ -395,7 +396,7 @@ Importantly, if some multipart request bodies contain complex objects (i.e. non-
 the `skip-form-model` property corresponding to your spec in the `application.properties` to `false`, e.g.:
 
 ```properties
-quarkus.openapi-generator.codegen.spec.my-multipart-requests_yml.skip-form-model=false
+quarkus.openapi-generator.codegen.spec.my_multipart_requests_yml.skip-form-model=false
 ```
 
 ### Default content-types according to OpenAPI Specification and limitations

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now, create the directory `openapi` under your `src/main/` path and add the Open
 To fine tune the configuration for each spec file, add the following entry to your properties file. In this example, our spec file is in `src/main/openapi/petstore.json`:
 
 ```properties
-quarkus.openapi-generator.codegen.spec."petstore_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.petstore_json.base-package=org.acme.openapi
 ```
 
 Note that the file name is used to configure the specific information for each spec. Periods (.) are replaced by underline (_).
@@ -279,7 +279,7 @@ Add the [SmallRye Fault Tolerance extension](https://quarkus.io/guides/smallrye-
 Assuming your Open API spec file is in `src/main/openapi/simple-openapi.json`, add the following configuration to your `application.properties` file:
 
 ````properties
-quarkus.openapi-generator.codegen.spec."simple-openapi_json".base-package=org.acme.openapi.simple
+quarkus.openapi-generator.codegen.spec.simple-openapi_json.base-package=org.acme.openapi.simple
 # Enables the CircuitBreaker extension for the byeGet method from the DefaultApi class
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 ````
@@ -395,7 +395,7 @@ Importantly, if some multipart request bodies contain complex objects (i.e. non-
 the `skip-form-model` property corresponding to your spec in the `application.properties` to `false`, e.g.:
 
 ```properties
-quarkus.openapi-generator.codegen.spec."my-multipart-requests_yml".skip-form-model=false
+quarkus.openapi-generator.codegen.spec.my-multipart-requests_yml.skip-form-model=false
 ```
 
 ### Default content-types according to OpenAPI Specification and limitations

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
+> **⚠️** This is the instructions for the latest SNAPSHOT version (main branch). Please, see the [latest **released** documentation]() if you are looking for instructions.
+
 Quarkus' extension for generation of [Rest Clients](https://quarkus.io/guides/rest-client) based on OpenAPI specification files.
 
 This extension is based on the [OpenAPI Generator Tool](https://openapi-generator.tech/). Please consider donation to help them maintain the
@@ -18,7 +20,7 @@ Add the following dependency to your project's `pom.xml` file:
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator</artifactId>
-  <version>0.5.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -50,10 +52,10 @@ Now, create the directory `openapi` under your `src/main/` path and add the Open
 To fine tune the configuration for each spec file, add the following entry to your properties file. In this example, our spec file is in `src/main/openapi/petstore.json`:
 
 ```properties
-quarkus.openapi-generator.codegen.spec."petstore.json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."petstore_json".base-package=org.acme.openapi
 ```
 
-Note that the file name is used to configure the specific information for each spec.
+Note that the file name is used to configure the specific information for each spec. Periods (.) are replaced by underline (_).
 
 Run `mvn compile` to generate your classes in `target/generated-sources/open-api-json` path:
 
@@ -277,7 +279,7 @@ Add the [SmallRye Fault Tolerance extension](https://quarkus.io/guides/smallrye-
 Assuming your Open API spec file is in `src/main/openapi/simple-openapi.json`, add the following configuration to your `application.properties` file:
 
 ````properties
-quarkus.openapi-generator.codegen.spec."simple-openapi.json".base-package=org.acme.openapi.simple
+quarkus.openapi-generator.codegen.spec."simple-openapi_json".base-package=org.acme.openapi.simple
 # Enables the CircuitBreaker extension for the byeGet method from the DefaultApi class
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 ````
@@ -299,7 +301,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
 
 @Path("")
-@RegisterRestClient
+@RegisterRestClient(baseUri="http://localhost/", configKey="simple-openapi_json")
 public interface DefaultApi {
 
     @GET
@@ -375,7 +377,7 @@ Then in the client the `org.jboss.resteasy.annotations.providers.multipart.Multi
 
 ```java
 @Path("/echo")
-@RegisterRestClient
+@RegisterRestClient(baseUri="http://my.endpoint.com/api/v1", configKey="multipart-requests_yml")
 public interface MultipartService {
 
     @POST
@@ -393,7 +395,7 @@ Importantly, if some multipart request bodies contain complex objects (i.e. non-
 the `skip-form-model` property corresponding to your spec in the `application.properties` to `false`, e.g.:
 
 ```properties
-quarkus.openapi-generator.codegen.spec."my-multipart-requests.yml".skip-form-model=false
+quarkus.openapi-generator.codegen.spec."my-multipart-requests_yml".skip-form-model=false
 ```
 
 ### Default content-types according to OpenAPI Specification and limitations

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-> **⚠️** This is the instructions for the latest SNAPSHOT version (main branch). Please, see the [latest **released** documentation]() if you are looking for instructions.
+> **⚠️** This is the instructions for the latest SNAPSHOT version (main branch). Please, see the [latest **released** documentation](https://github.com/quarkiverse/quarkus-openapi-generator/blob/0.5.0/README.md) if you are looking for instructions.
 
 Quarkus' extension for generation of [Rest Clients](https://quarkus.io/guides/rest-client) based on OpenAPI specification files.
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.common.utils.StringUtil;
 
 // This configuration is read in codegen phase (before build time), the annotation is for document purposes and avoiding quarkus warns
 @ConfigRoot(name = SpecConfig.BUILD_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
@@ -48,11 +49,11 @@ public class SpecConfig {
      * Every the periods (.) in the file name will be replaced by underscore (_).
      */
     public static String getBuildTimeSpecPropertyPrefix(final Path openApiFilePath) {
-        return String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, getEscapedFileName(openApiFilePath));
+        return String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, getSanitizedFileName(openApiFilePath));
     }
 
-    public static String getEscapedFileName(final Path openApiFilePath) {
-        final String uriFilePath = openApiFilePath.toUri().toString();
-        return uriFilePath.substring(uriFilePath.lastIndexOf("/") + 1).replaceAll("\\.", "_");
+    public static String getSanitizedFileName(final Path openApiFilePath) {
+        final String fileName = openApiFilePath.getFileName().toString();
+        return StringUtil.replaceNonAlphanumericByUnderscores(fileName.substring(fileName.lastIndexOf("/") + 1));
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
@@ -15,7 +15,7 @@ public class SpecConfig {
     public static final String API_PKG_SUFFIX = ".api";
     public static final String MODEL_PKG_SUFFIX = ".model";
     // package visibility for unit tests
-    static final String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + BUILD_TIME_CONFIG_PREFIX + ".spec.\"%s\"";
+    static final String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + BUILD_TIME_CONFIG_PREFIX + ".spec.%s";
     private static final String BASE_PACKAGE_PROP_FORMAT = "%s.base-package";
     private static final String SKIP_FORM_MODEL_PROP_FORMAT = "%s.skip-form-model";
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
@@ -53,7 +53,6 @@ public class SpecConfig {
     }
 
     public static String getSanitizedFileName(final Path openApiFilePath) {
-        final String fileName = openApiFilePath.getFileName().toString();
-        return StringUtil.replaceNonAlphanumericByUnderscores(fileName.substring(fileName.lastIndexOf("/") + 1));
+        return StringUtil.replaceNonAlphanumericByUnderscores(openApiFilePath.getFileName().toString());
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecConfig.java
@@ -44,14 +44,15 @@ public class SpecConfig {
     /**
      * Gets the config prefix for a given OpenAPI file in the path.
      * For example, given a path like /home/luke/projects/petstore.json, the returned value is
-     * `quarkus.openapi-generator."petstore.json"`.
+     * `quarkus.openapi-generator."petstore_json"`.
+     * Every the periods (.) in the file name will be replaced by underscore (_).
      */
     public static String getBuildTimeSpecPropertyPrefix(final Path openApiFilePath) {
         return String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, getEscapedFileName(openApiFilePath));
     }
 
-    private static String getEscapedFileName(final Path openApiFilePath) {
+    public static String getEscapedFileName(final Path openApiFilePath) {
         final String uriFilePath = openApiFilePath.toUri().toString();
-        return uriFilePath.substring(uriFilePath.lastIndexOf("/") + 1);
+        return uriFilePath.substring(uriFilePath.lastIndexOf("/") + 1).replaceAll("\\.", "_");
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
+import static io.quarkiverse.openapi.generator.deployment.SpecConfig.getEscapedFileName;
 import static io.quarkiverse.openapi.generator.deployment.SpecConfig.resolveApiPackage;
 import static io.quarkiverse.openapi.generator.deployment.SpecConfig.resolveModelPackage;
 import static java.lang.Boolean.FALSE;
@@ -7,6 +8,7 @@ import static java.lang.Boolean.TRUE;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +53,8 @@ public class OpenApiClientGeneratorWrapper {
         this.configurator = new QuarkusCodegenConfigurator();
         this.configurator.setInputSpec(specFilePath.toString());
         this.configurator.setOutputDir(outputDir.toString());
+        this.configurator.addAdditionalProperty("quarkus-generator",
+                Collections.singletonMap("openApiSpecId", getEscapedFileName(specFilePath)));
         this.generator = new DefaultGenerator();
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
-import static io.quarkiverse.openapi.generator.deployment.SpecConfig.getEscapedFileName;
+import static io.quarkiverse.openapi.generator.deployment.SpecConfig.getSanitizedFileName;
 import static io.quarkiverse.openapi.generator.deployment.SpecConfig.resolveApiPackage;
 import static io.quarkiverse.openapi.generator.deployment.SpecConfig.resolveModelPackage;
 import static java.lang.Boolean.FALSE;
@@ -54,7 +54,7 @@ public class OpenApiClientGeneratorWrapper {
         this.configurator.setInputSpec(specFilePath.toString());
         this.configurator.setOutputDir(outputDir.toString());
         this.configurator.addAdditionalProperty("quarkus-generator",
-                Collections.singletonMap("openApiSpecId", getEscapedFileName(specFilePath)));
+                Collections.singletonMap("openApiSpecId", getSanitizedFileName(specFilePath)));
         this.generator = new DefaultGenerator();
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -5,10 +5,17 @@ import java.io.File;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.utils.ProcessUtils;
+import org.openapitools.codegen.utils.URLPathUtils;
+
+import io.swagger.v3.oas.models.OpenAPI;
 
 public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     private static final String AUTH_PACKAGE = "auth";
+    /**
+     * Default server URL (the first one in the OpenAPI spec file servers definition.
+     */
+    private static final String DEFAULT_SERVER_URL = "defaultServerUrl";
 
     public QuarkusJavaClientCodegen() {
         // immutable properties
@@ -42,11 +49,11 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                 ProcessUtils.hasHttpBearerMethods(this.openAPI) ||
                 ProcessUtils.hasOAuthMethods(this.openAPI)) {
             supportingFiles.add(
-                    new SupportingFile("auth/compositeAuthenticationProvider.qute",
+                    new SupportingFile(AUTH_PACKAGE + "/compositeAuthenticationProvider.qute",
                             authFileFolder(),
                             "CompositeAuthenticationProvider.java"));
             supportingFiles.add(
-                    new SupportingFile("auth/authConfig.qute",
+                    new SupportingFile(AUTH_PACKAGE + "/authConfig.qute",
                             authFileFolder(),
                             "AuthConfiguration.java"));
         }
@@ -62,5 +69,12 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
         // we are not using the apiFileFolder since it returns the full path
         // we are only interested in the package path
         return apiPackage().replace('.', File.separatorChar) + File.separator + AUTH_PACKAGE;
+    }
+
+    @Override
+    public void preprocessOpenAPI(OpenAPI openAPI) {
+        super.preprocessOpenAPI(openAPI);
+        // add the default server url to the context
+        additionalProperties.put(DEFAULT_SERVER_URL, URLPathUtils.getServerURL(this.openAPI, serverVariableOverrides()));
     }
 }

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -29,7 +29,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
   */
 {/if}
 @Path("{#if useAnnotatedBasePath}{contextPath}{/if}{commonPath}")
-@RegisterRestClient
+@RegisterRestClient(baseUri="{defaultServerUrl}", configKey="{quarkus-generator.openApiSpecId}")
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if hasAuthMethods}
 @RegisterProvider(CompositeAuthenticationProvider.class)

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/SpecConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/SpecConfigTest.java
@@ -13,13 +13,13 @@ class SpecConfigTest {
     void verifySpaceEncoding() {
         final String resolvedPrefix = SpecConfig
                 .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/luke/my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi.json"));
+        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi_json"));
     }
 
     @Test
     void withSingleFileName() {
         final String resolvedPrefix = SpecConfig.getBuildTimeSpecPropertyPrefix(Path.of("my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi.json"));
+        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi_json"));
     }
 
 }

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/SpecConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/SpecConfigTest.java
@@ -13,13 +13,13 @@ class SpecConfigTest {
     void verifySpaceEncoding() {
         final String resolvedPrefix = SpecConfig
                 .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/luke/my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi_json"));
+        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
     }
 
     @Test
     void withSingleFileName() {
         final String resolvedPrefix = SpecConfig.getBuildTimeSpecPropertyPrefix(Path.of("my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my%20test%20openapi_json"));
+        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
     }
 
 }

--- a/deployment/src/test/resources/circuitbreaker/application.properties
+++ b/deployment/src/test/resources/circuitbreaker/application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api.json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries.json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/enabled=true
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/deployment/src/test/resources/circuitbreaker/application.properties
+++ b/deployment/src/test/resources/circuitbreaker/application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.any_api_json.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.restcountries_json.base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/enabled=true
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
@@ -1,5 +1,5 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec.any-api_json.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.any_api_json.base-package=org.acme.openapi
 quarkus.openapi-generator.codegen.spec.restcountries_json.base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/enabled=false

--- a/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api.json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries.json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/enabled=false
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/circuit_breaker_disabled_application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.any-api_json.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.restcountries_json.base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/enabled=false
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
@@ -1,5 +1,5 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec.any-api_json.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.any_api_json.base-package=org.acme.openapi
 quarkus.openapi-generator.codegen.spec.restcountries_json.base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.any-api_json.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.restcountries_json.base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException
 org.acme.CountryResource/getCountries/CircuitBreaker/skipOn = java.lang.NumberFormatException, java.lang.IndexOutOfBoundsException

--- a/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
+++ b/deployment/src/test/resources/circuitbreaker/missing_circuit_breaker_enabled_application.properties
@@ -1,6 +1,6 @@
 # used by io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParserTest
-quarkus.openapi-generator.codegen.spec."any-api.json".base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec."restcountries.json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."any-api_json".base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec."restcountries_json".base-package=org.acme.openapi
 
 org.acme.CountryResource/getCountries/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException
 org.acme.CountryResource/getCountries/CircuitBreaker/skipOn = java.lang.NumberFormatException, java.lang.IndexOutOfBoundsException

--- a/deployment/src/test/resources/codegen/application.properties
+++ b/deployment/src/test/resources/codegen/application.properties
@@ -1,6 +1,6 @@
 
 # Base package for our generated code
-quarkus.openapi-generator.codegen.spec.issue-38_yaml.base-package=org.issue38
+quarkus.openapi-generator.codegen.spec.issue_38_yaml.base-package=org.issue38
 
 # Should we generate deprecated attributes for the given model?
 # By default, deprecated attributes in model classes are generated

--- a/deployment/src/test/resources/codegen/application.properties
+++ b/deployment/src/test/resources/codegen/application.properties
@@ -1,6 +1,6 @@
 
 # Base package for our generated code
-quarkus.openapi-generator.codegen.spec."issue-38_yaml".base-package=org.issue38
+quarkus.openapi-generator.codegen.spec.issue-38_yaml.base-package=org.issue38
 
 # Should we generate deprecated attributes for the given model?
 # By default, deprecated attributes in model classes are generated

--- a/deployment/src/test/resources/codegen/application.properties
+++ b/deployment/src/test/resources/codegen/application.properties
@@ -1,6 +1,6 @@
 
 # Base package for our generated code
-quarkus.openapi-generator.codegen.spec."issue-38.yaml".base-package=org.issue38
+quarkus.openapi-generator.codegen.spec."issue-38_yaml".base-package=org.issue38
 
 # Should we generate deprecated attributes for the given model?
 # By default, deprecated attributes in model classes are generated

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -4,11 +4,11 @@ org.acme.openapi.security.auth.basic_auth/password=test
 
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
-quarkus.openapi-generator.codegen.spec.open%20weather_yaml.base-package=org.acme.openapi.weather
+quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
 # Authentication properties
 org.acme.openapi.weather.security.auth.app_id/api-key=12345
 
-quarkus.openapi-generator.codegen.spec.simple-openapi_json.base-package=org.acme.openapi.simple
+quarkus.openapi-generator.codegen.spec.simple_openapi_json.base-package=org.acme.openapi.simple
 
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException
@@ -20,6 +20,6 @@ org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failureRatio = 3.14
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/successThreshold = 22
 
 
-quarkus.openapi-generator.codegen.spec.multipart-requests_yml.base-package=org.acme.openapi.multipart
+quarkus.openapi-generator.codegen.spec.multipart_requests_yml.base-package=org.acme.openapi.multipart
 # By default the openapi-generator doesn't generate models for multipart requests
-quarkus.openapi-generator.codegen.spec.multipart-requests_yml.skip-form-model=false
+quarkus.openapi-generator.codegen.spec.multipart_requests_yml.skip-form-model=false

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -4,11 +4,11 @@ org.acme.openapi.security.auth.basic_auth/password=test
 
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
-quarkus.openapi-generator.codegen.spec."open%20weather_yaml".base-package=org.acme.openapi.weather
+quarkus.openapi-generator.codegen.spec.open%20weather_yaml.base-package=org.acme.openapi.weather
 # Authentication properties
 org.acme.openapi.weather.security.auth.app_id/api-key=12345
 
-quarkus.openapi-generator.codegen.spec."simple-openapi_json".base-package=org.acme.openapi.simple
+quarkus.openapi-generator.codegen.spec.simple-openapi_json.base-package=org.acme.openapi.simple
 
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException
@@ -20,6 +20,6 @@ org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failureRatio = 3.14
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/successThreshold = 22
 
 
-quarkus.openapi-generator.codegen.spec."multipart-requests_yml".base-package=org.acme.openapi.multipart
+quarkus.openapi-generator.codegen.spec.multipart-requests_yml.base-package=org.acme.openapi.multipart
 # By default the openapi-generator doesn't generate models for multipart requests
-quarkus.openapi-generator.codegen.spec."multipart-requests_yml".skip-form-model=false
+quarkus.openapi-generator.codegen.spec.multipart-requests_yml.skip-form-model=false

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -4,11 +4,11 @@ org.acme.openapi.security.auth.basic_auth/password=test
 
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
-quarkus.openapi-generator.codegen.spec."open%20weather.yaml".base-package=org.acme.openapi.weather
+quarkus.openapi-generator.codegen.spec."open%20weather_yaml".base-package=org.acme.openapi.weather
 # Authentication properties
 org.acme.openapi.weather.security.auth.app_id/api-key=12345
 
-quarkus.openapi-generator.codegen.spec."simple-openapi.json".base-package=org.acme.openapi.simple
+quarkus.openapi-generator.codegen.spec."simple-openapi_json".base-package=org.acme.openapi.simple
 
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException
@@ -20,6 +20,6 @@ org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failureRatio = 3.14
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/successThreshold = 22
 
 
-quarkus.openapi-generator.codegen.spec."multipart-requests.yml".base-package=org.acme.openapi.multipart
+quarkus.openapi-generator.codegen.spec."multipart-requests_yml".base-package=org.acme.openapi.multipart
 # By default the openapi-generator doesn't generate models for multipart requests
-quarkus.openapi-generator.codegen.spec."multipart-requests.yml".skip-form-model=false
+quarkus.openapi-generator.codegen.spec."multipart-requests_yml".skip-form-model=false

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherTest.java
@@ -27,7 +27,7 @@ public class OpenWeatherTest {
     @ConfigProperty(name = "org.acme.openapi.weather.security.auth.app_id/api-key")
     String apiKey;
 
-    @ConfigProperty(name = "org.acme.openapi.weather.api.CurrentWeatherDataApi/mp-rest/url")
+    @ConfigProperty(name = WiremockOpenWeather.URL_KEY)
     String weatherUrl;
 
     @RestClient

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
@@ -15,7 +15,7 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
 
     private WireMockServer wireMockServer;
 
-    public static final String URL_KEY = "quarkus.rest-client.\"open%20weather_yaml\".url";
+    public static final String URL_KEY = "quarkus.rest-client.open_weather_yaml.url";
 
     @Override
     public Map<String, String> start() {

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
@@ -15,6 +15,8 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
 
     private WireMockServer wireMockServer;
 
+    public static final String URL_KEY = "quarkus.rest-client.\"open%20weather_yaml\".url";
+
     @Override
     public Map<String, String> start() {
         wireMockServer = new WireMockServer(8888);
@@ -26,7 +28,7 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
                         .withHeader("Content-Type", "application/json")
                         .withBody(
                                 "{\"name\": \"Nowhere\"}")));
-        return Collections.singletonMap("org.acme.openapi.weather.api.CurrentWeatherDataApi/mp-rest/url",
+        return Collections.singletonMap(URL_KEY,
                 wireMockServer.baseUrl().concat("/data/2.5"));
     }
 

--- a/integration-tests/generation-tests/src/main/resources/application.properties
+++ b/integration-tests/generation-tests/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.openapi-generator.codegen.spec."petstore_json".base-package=org.acme.petstore
+quarkus.openapi-generator.codegen.spec.petstore_json.base-package=org.acme.petstore
 # This one is passed through the Classpath source provider. Uncomment to overwrite it
-#quarkus.openapi-generator.codegen.spec."subtraction.yaml".base-package=org.acme.subtraction
+#quarkus.openapi-generator.codegen.spec.subtraction_yaml.base-package=org.acme.subtraction
 quarkus.oidc-client.client-enabled=false
 # ${keycloak.url} is provided by test-utils
 # petstore_auth is the name of the security scheme from the openapi spec file (petstore.json)

--- a/integration-tests/generation-tests/src/main/resources/application.properties
+++ b/integration-tests/generation-tests/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.openapi-generator.codegen.spec."petstore.json".base-package=org.acme.petstore
+quarkus.openapi-generator.codegen.spec."petstore_json".base-package=org.acme.petstore
 # This one is passed through the Classpath source provider. Uncomment to overwrite it
 #quarkus.openapi-generator.codegen.spec."subtraction.yaml".base-package=org.acme.subtraction
 quarkus.oidc-client.client-enabled=false

--- a/˜!
+++ b/˜!
@@ -1,4 +1,0 @@
-release:
-  current-version: 0.5.0
-  next-version: 1.0.0-SNAPSHOT
-


### PR DESCRIPTION
In this PR, we changed the OpenAPI Spec file in the configuration keys to use underline (_) in place of (.). This is a breaking change, we will notify users in the release notes to change their configuration. With this change, users can set properties without the quotes, like:

```properties
quarkus.openapi-generator.codegen.spec.simple_openapi_json.base-package=org.acme.openapi.simple
```
For a file named `simple-openapi.json`. We follow the rules defined [here](https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#environment-variables-mapping-rules) from Microprofile Configuration project. 

Additionally, now the `baseUri` and `configPrefix` attributes is defined in the generated `@RegisterRestClient` annotation. For example:

```java
@RegisterRestClient(baseUri="http://localhost/", configKey="simple_openapi_json")
public interface DefaultApi { }
```

You can override the URL using quarkus properties:

```properties
quarkus.rest-client.simple_openapi_json.url=http://my-new-address.com/
```

