### PR TITLE
Add token propagation support

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenBuildTimeConfig.java
@@ -9,8 +9,8 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.common.utils.StringUtil;
 
 // This configuration is read in codegen phase (before build time), the annotation is for document purposes and avoiding quarkus warns
-@ConfigRoot(name = CodegenConfig.CODEGEN_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
-public class CodegenConfig {
+@ConfigRoot(name = CodegenBuildTimeConfig.CODEGEN_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
+public class CodegenBuildTimeConfig {
 
     static final String CODEGEN_TIME_CONFIG_PREFIX = "openapi-generator.codegen";
 
@@ -26,7 +26,7 @@ public class CodegenConfig {
      * OpenAPI Spec details for codegen configuration.
      */
     @ConfigItem(name = "spec")
-    public Map<String, SpecItemConfig> specItem;
+    public Map<String, SpecItemBuildTimeConfig> specItem;
 
     /**
      * Whether to log the internal generator codegen process in the default output or not.

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemBuildTimeConfig.java
@@ -12,7 +12,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Not meant to be used outside this scope.
  */
 @ConfigGroup
-public class SpecItemConfig {
+public class SpecItemBuildTimeConfig {
 
     /**
      * Base package for where the generated code for the given OpenAPI specification will be added.

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ModelCodegenConfigParser.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ModelCodegenConfigParser.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.resolveModelPackage;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.resolveModelPackage;
 
 import java.util.HashMap;
 import java.util.List;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -1,9 +1,9 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VERBOSE_PROPERTY_NAME;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getBasePackagePropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSanitizedFileName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSkipFormModelPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.VERBOSE_PROPERTY_NAME;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.getBasePackagePropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.getSanitizedFileName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.getSkipFormModelPropertyName;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/SpecInputModel.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/SpecInputModel.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-import io.quarkiverse.openapi.generator.deployment.CodegenConfig;
+import io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig;
 import io.smallrye.config.PropertiesConfigSource;
 
 public class SpecInputModel {
@@ -33,7 +33,7 @@ public class SpecInputModel {
      */
     public SpecInputModel(final String filename, final InputStream inputStream, final String basePackageName) {
         this(filename, inputStream);
-        this.codegenProperties.put(CodegenConfig.getBasePackagePropertyName(Path.of(filename)), basePackageName);
+        this.codegenProperties.put(CodegenBuildTimeConfig.getBasePackagePropertyName(Path.of(filename)), basePackageName);
     }
 
     public String getFileName() {

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
@@ -27,7 +27,6 @@ public class QuteTemplatingEngineAdapter extends AbstractTemplatingEngineAdapter
             "pojo.qute",
             "queryParams.qute",
             "auth/compositeAuthenticationProvider.qute",
-            "auth/authConfig.qute",
             "multipartFormdataPojo.qute"
     };
     public final Engine engine;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -1,8 +1,8 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSanitizedFileName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.resolveApiPackage;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.resolveModelPackage;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.getSanitizedFileName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.resolveApiPackage;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.resolveModelPackage;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.requireNonNull;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -53,10 +53,6 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                     new SupportingFile(AUTH_PACKAGE + "/compositeAuthenticationProvider.qute",
                             authFileFolder(),
                             "CompositeAuthenticationProvider.java"));
-            supportingFiles.add(
-                    new SupportingFile(AUTH_PACKAGE + "/authConfig.qute",
-                            authFileFolder(),
-                            "AuthConfiguration.java"));
         }
 
         apiTemplateFiles.clear();

--- a/deployment/src/main/resources/templates/auth/authConfig.qute
+++ b/deployment/src/main/resources/templates/auth/authConfig.qute
@@ -1,9 +1,0 @@
-package {apiPackage}.auth;
-
-import io.quarkiverse.openapi.generator.providers.AuthProvidersConfig;
-import io.smallrye.config.ConfigMapping;
-
-@ConfigMapping(prefix = "{packageName}.security")
-public interface AuthConfiguration extends AuthProvidersConfig {
-
-}

--- a/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
+++ b/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
@@ -5,6 +5,9 @@ import javax.annotation.PostConstruct;
 import javax.ws.rs.Priorities;
 
 import io.quarkus.arc.Priority;
+
+import io.quarkiverse.openapi.generator.CodegenConfig;
+
 {#if hasHttpBasicMethods}
 import io.quarkiverse.openapi.generator.providers.BasicAuthenticationProvider;
 {/if}
@@ -25,19 +28,19 @@ import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 public class CompositeAuthenticationProvider extends AbstractCompositeAuthenticationProvider {
 
     @Inject
-    AuthConfiguration authConfig;
+    CodegenConfig codegenConfig;
 
     @PostConstruct
     public void init() {
         {#for auth in httpBasicMethods.orEmpty}
-        this.addAuthenticationProvider(new BasicAuthenticationProvider("{auth.name}", authConfig)
+        this.addAuthenticationProvider(new BasicAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}
         {#for authM in op.authMethods}
         {#if authM.name == auth.name}
             .addOperation(OperationAuthInfo.builder()
-                .withPath("{api.contextPath}{api.commonPath{op.path.orEmpty}")
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
                 .withId("{op.operationId}")
                 .withMethod("{op.httpMethod}")
                 .build())
@@ -48,7 +51,7 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for});
         {/for}
         {#for auth in oauthMethods.orEmpty}
-        this.addAuthenticationProvider(new OAuth2AuthenticationProvider("{auth.name}")
+        this.addAuthenticationProvider(new OAuth2AuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}
@@ -66,7 +69,7 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for});
         {/for}
         {#for auth in httpBearerMethods.orEmpty}
-        this.addAuthenticationProvider(new BearerAuthenticationProvider("{auth.name}", "{auth.scheme}", authConfig)
+        this.addAuthenticationProvider(new BearerAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), "{auth.scheme}", codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}
@@ -85,7 +88,7 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for}
         {#for auth in apiKeyMethods.orEmpty}
         {#if auth.isKeyInQuery}
-        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{auth.name}", ApiKeyIn.query, "{auth.keyParamName}", authConfig)
+        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), ApiKeyIn.query, "{auth.keyParamName}", codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}
@@ -103,7 +106,7 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for});
         {/if}
         {#if auth.isKeyInHeader}
-        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{auth.name}", ApiKeyIn.header, "{auth.keyParamName}", authConfig)
+        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), ApiKeyIn.header, "{auth.keyParamName}", codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}
@@ -121,7 +124,7 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for});
         {/if}
         {#if auth.isKeyInCookie}
-        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{auth.name}", ApiKeyIn.cookie, "{auth.keyParamName}", authConfig)
+        this.addAuthenticationProvider(new ApiKeyAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), ApiKeyIn.cookie, "{auth.keyParamName}", codegenConfig)
         {#for api in apiInfo.apis}
         {#for op in api.operations.operation}
         {#if op.hasAuthMethods}

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.BUILD_TIME_SPEC_PREFIX_FORMAT;
+import static io.quarkiverse.openapi.generator.deployment.CodegenBuildTimeConfig.BUILD_TIME_SPEC_PREFIX_FORMAT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
@@ -11,14 +11,14 @@ class CodegenConfigTest {
 
     @Test
     void verifySpaceEncoding() {
-        final String resolvedPrefix = CodegenConfig
+        final String resolvedPrefix = CodegenBuildTimeConfig
                 .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/luke/my test openapi.json"));
         assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
     }
 
     @Test
     void withSingleFileName() {
-        final String resolvedPrefix = CodegenConfig.getBuildTimeSpecPropertyPrefix(Path.of("my test openapi.json"));
+        final String resolvedPrefix = CodegenBuildTimeConfig.getBuildTimeSpecPropertyPrefix(Path.of("my test openapi.json"));
         assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
     }
 

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -6,7 +6,7 @@ org.acme.openapi.security.auth.basic_auth/password=test
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
 quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
 # Authentication properties
-org.acme.openapi.weather.security.auth.app_id/api-key=12345
+quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
 
 
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherTest.java
@@ -24,7 +24,7 @@ public class OpenWeatherTest {
     // injected by quarkus test resource
     WireMockServer openWeatherServer;
 
-    @ConfigProperty(name = "org.acme.openapi.weather.security.auth.app_id/api-key")
+    @ConfigProperty(name = "quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key")
     String apiKey;
 
     @ConfigProperty(name = WiremockOpenWeather.URL_KEY)

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/CodegenConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/CodegenConfig.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.openapi.generator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.common.utils.StringUtil;
+
+/**
+ * This class represents the runtime configurations for the openapi-generator extension.
+ */
+@ConfigRoot(name = CodegenConfig.RUNTIME_TIME_CONFIG_PREFIX, phase = ConfigPhase.RUN_TIME)
+public class CodegenConfig {
+
+    public static final String RUNTIME_TIME_CONFIG_PREFIX = "openapi-generator";
+
+    /**
+     * Configurations of the individual OpenApi spec definitions, i.e. the provided files.
+     * <p>
+     * The key must be any of the sanitized names of the OpenApi definition files.
+     * For example, a file named petstore.json is sanitized into the name petstore_json, and thus the specific
+     * configurations this file must start with the prefix quarkus.openapi-generator.petstore_json
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public Map<String, SpecItemConfig> itemConfigs;
+
+    public Optional<SpecItemConfig> getItemConfig(String specItem) {
+        return Optional.ofNullable(itemConfigs.get(specItem));
+    }
+
+    @Override
+    public String toString() {
+        return "CodegenConfig{" +
+                "itemConfigs=" + itemConfigs +
+                '}';
+    }
+
+    public static String getSanitizedSecuritySchemeName(final String securitySchemeName) {
+        return StringUtil.replaceNonAlphanumericByUnderscores(securitySchemeName);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/CodegenException.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/CodegenException.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.openapi.generator;
+
+public class CodegenException extends RuntimeException {
+
+    public CodegenException(String message) {
+        super(message);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemAuthConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemAuthConfig.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.openapi.generator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkiverse.openapi.generator.providers.ApiKeyAuthenticationProvider;
+import io.quarkiverse.openapi.generator.providers.BasicAuthenticationProvider;
+import io.quarkiverse.openapi.generator.providers.BearerAuthenticationProvider;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * This class represents the runtime authentication related configuration for an individual securityScheme present
+ * on an OpenApi spec definition, i.e. the provided files.
+ */
+@ConfigGroup
+public class SpecItemAuthConfig {
+
+    public static final String TOKEN_PROPAGATION = "token-propagation";
+    public static final String HEADER_NAME = "header-name";
+
+    /**
+     * Enables the authentication token propagation for this particular securityScheme.
+     * <p>
+     * For example, given a file named petstore.json with a securityScheme named "petstore-auth" the following configuration
+     * must be used.
+     * <p>
+     * quarkus.openapi-generator.petstore_json.auth.petstore_auth.token-propagation=true
+     * 
+     * @see SpecItemAuthsConfig
+     * @see SpecItemConfig
+     * @see CodegenConfig
+     */
+    @ConfigItem(defaultValue = "false")
+    public Optional<Boolean> tokenPropagation;
+
+    /**
+     * Configures a particular http header attribute from were to take the security token from when the token propagation
+     * is enabled. Use this fine-grained configuration in very particular scenarios.
+     * <p>
+     * For example, given a file named petstore.json with a securityScheme named "petstore-auth" the following configuration
+     * must be used.
+     * <p>
+     * quarkus.openapi-generator.petstore_json.auth.petstore_auth.header-name=MyParticularHttpHeaderName
+     * 
+     * @see SpecItemAuthsConfig
+     * @see SpecItemConfig
+     * @see CodegenConfig
+     */
+    @ConfigItem
+    public Optional<String> headerName;
+
+    /**
+     * Configures a particular parameter value to be used by any of the different internal authentication filters
+     * that processes the different securityScheme definitions.
+     * <p>
+     * For example, given a file named petstore.json with a securityScheme named "petstore-basic-auth", that is of
+     * http basic authentication type, the following configuration can establish the user and password to be used.
+     * must be used.
+     * <p>
+     * quarkus.openapi-generator.petstore_json.auth.petstore_basic_auth.username=MyUserName
+     * quarkus.openapi-generator.petstore_json.auth.petstore_basic_auth.password=MyPassword
+     * 
+     * @see SpecItemAuthsConfig
+     * @see SpecItemConfig
+     * @see CodegenConfig
+     * @see BasicAuthenticationProvider
+     * @see BearerAuthenticationProvider
+     * @see ApiKeyAuthenticationProvider
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public Map<String, String> authConfigParams;
+
+    public Optional<Boolean> getTokenPropagation() {
+        return tokenPropagation;
+    }
+
+    public Optional<String> getHeaderName() {
+        return headerName;
+    }
+
+    public Optional<String> getConfigParam(String paramName) {
+        return Optional.ofNullable(authConfigParams.get(paramName));
+    }
+
+    @Override
+    public String toString() {
+        return "SpecRuntimeAuthConfig{" +
+                "tokenPropagation=" + tokenPropagation +
+                ", headerName=" + headerName +
+                ", authConfigParams=" + authConfigParams +
+                '}';
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemAuthsConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemAuthsConfig.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.openapi.generator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class SpecItemAuthsConfig {
+
+    /**
+     * Configurations for the individual securitySchemes present on a given OpenApi spec definition file.
+     * <p>
+     * The key must be any of the sanitized names of the securitySchemes.
+     * For example, given a file named petstore.json with a securityScheme named "petstore-auth", we have that the file
+     * name is sanitized into the name petstore_json and the security scheme name is sanitized into the name
+     * "petstore_auth". And thus, the specific configurations for this security scheme must start with the prefix
+     * quarkus.openapi-generator.petstore_json.auth.petstore_auth
+     * 
+     * @see SpecItemConfig
+     * @see SpecItemAuthConfig
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public Map<String, SpecItemAuthConfig> authConfigs;
+
+    public Optional<SpecItemAuthConfig> getItemConfig(String authConfig) {
+        return Optional.ofNullable(authConfigs.get(authConfig));
+    }
+
+    @Override
+    public String toString() {
+        return "SpecRuntimeAuthConfigs{" +
+                "authConfigs=" + authConfigs +
+                '}';
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.openapi.generator;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * This class represents the runtime authentication related configurations for the individual OpenApi spec definitions,
+ * i.e. the provided files.
+ */
+@ConfigGroup
+public class SpecItemConfig {
+
+    /**
+     * Authentication related configurations for the different securitySchemes present on a given OpenApi spec
+     * definition file.
+     * <p>
+     * For example, given a file named petstore.json, the following prefix must be used to configure the authentication
+     * related information quarkus.openapi-generator.petstore_json.auth
+     * 
+     * @see SpecItemAuthsConfig
+     */
+    @ConfigItem
+    public SpecItemAuthsConfig auth;
+
+    public Optional<SpecItemAuthsConfig> getAuth() {
+        return Optional.ofNullable(auth);
+    }
+
+    @Override
+    public String toString() {
+        return "SpecItemConfig{" +
+                "auth=" + auth +
+                '}';
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthProvider.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.openapi.generator.providers;
+
+import static io.quarkiverse.openapi.generator.CodegenConfig.RUNTIME_TIME_CONFIG_PREFIX;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+
+import io.quarkiverse.openapi.generator.CodegenConfig;
+import io.quarkiverse.openapi.generator.SpecItemAuthConfig;
+import io.quarkiverse.openapi.generator.SpecItemAuthsConfig;
+import io.quarkiverse.openapi.generator.SpecItemConfig;
+
+public abstract class AbstractAuthProvider implements AuthProvider {
+
+    private static final String CANONICAL_AUTH_CONFIG_PROPERTY_NAME = "quarkus." +
+            RUNTIME_TIME_CONFIG_PREFIX + ".%s.auth.%s.%s";
+
+    private final String openApiSpecId;
+    private final String name;
+    private final CodegenConfig codegenConfig;
+    private SpecItemAuthConfig specItemAuthConfig;
+    private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
+
+    protected AbstractAuthProvider(String openApiSpecId, String name, CodegenConfig codegenConfig) {
+        this.openApiSpecId = openApiSpecId;
+        this.name = name;
+        this.codegenConfig = codegenConfig;
+        Optional<SpecItemConfig> specItemConfig = codegenConfig.getItemConfig(openApiSpecId);
+        if (specItemConfig.isPresent()) {
+            Optional<SpecItemAuthsConfig> authsConfig = specItemConfig.get().getAuth();
+            authsConfig.ifPresent(
+                    specItemAuthsConfig -> specItemAuthConfig = specItemAuthsConfig.getItemConfig(name).orElse(null));
+        }
+    }
+
+    public String getOpenApiSpecId() {
+        return openApiSpecId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public CodegenConfig getCodegenConfig() {
+        return codegenConfig;
+    }
+
+    public boolean isTokenPropagation() {
+        return specItemAuthConfig != null && specItemAuthConfig.getTokenPropagation().orElse(false);
+    }
+
+    public String getTokenForPropagation(MultivaluedMap<String, Object> httpHeaders) {
+        if (getHeaderName() != null) {
+            return Objects.toString(httpHeaders.getFirst(getHeaderName()));
+        } else {
+            return Objects.toString(httpHeaders.getFirst(HttpHeaders.AUTHORIZATION));
+        }
+    }
+
+    public String getHeaderName() {
+        if (specItemAuthConfig != null) {
+            return specItemAuthConfig.getHeaderName().orElse(null);
+        }
+        return null;
+    }
+
+    @Override
+    public List<OperationAuthInfo> operationsToFilter() {
+        return applyToOperations;
+    }
+
+    @Override
+    public AuthProvider addOperation(OperationAuthInfo operationAuthInfo) {
+        this.applyToOperations.add(operationAuthInfo);
+        return this;
+    }
+
+    public String getAuthConfigParam(String paramName, String defaultValue) {
+        if (specItemAuthConfig != null) {
+            return specItemAuthConfig.getConfigParam(paramName).orElse(defaultValue);
+        }
+        return defaultValue;
+    }
+
+    protected String getCanonicalAuthConfigPropertyName(String authPropertyName) {
+        return String.format(CANONICAL_AUTH_CONFIG_PROPERTY_NAME, getOpenApiSpecId(), getName(), authPropertyName);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractCompositeAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractCompositeAuthenticationProvider.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 
+import io.quarkiverse.openapi.generator.CodegenConfig;
+
 /**
  * Composition of supported {@link ClientRequestFilter} defined by a given OpenAPI interface.
  * This class is used as the base class of generated code.
@@ -37,4 +39,7 @@ public abstract class AbstractCompositeAuthenticationProvider implements ClientR
                         o.matchPath(requestContext.getUri().getPath()));
     }
 
+    protected static String sanitizeAuthName(String schemeName) {
+        return CodegenConfig.getSanitizedSecuritySchemeName(schemeName);
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
@@ -1,30 +1,33 @@
 package io.quarkiverse.openapi.generator.providers;
 
+import static io.quarkiverse.openapi.generator.SpecItemAuthConfig.TOKEN_PROPAGATION;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.UriBuilder;
 
+import io.quarkiverse.openapi.generator.CodegenConfig;
+import io.quarkiverse.openapi.generator.CodegenException;
+
 /**
  * Provider for API Key authentication.
  */
-public class ApiKeyAuthenticationProvider implements AuthProvider {
+public class ApiKeyAuthenticationProvider extends AbstractAuthProvider {
 
-    private final String name;
+    private static final String API_KEY = "api-key";
+
     private final ApiKeyIn apiKeyIn;
     private final String apiKeyName;
-    private final AuthProvidersConfig authProvidersConfig;
-    private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
 
-    public ApiKeyAuthenticationProvider(final String name, final ApiKeyIn apiKeyIn, final String apiKeyName,
-            final AuthProvidersConfig authProvidersConfig) {
+    public ApiKeyAuthenticationProvider(final String openApiSpecId, final String name, final ApiKeyIn apiKeyIn,
+            final String apiKeyName,
+            final CodegenConfig codegenConfig) {
+        super(openApiSpecId, name, codegenConfig);
         this.apiKeyIn = apiKeyIn;
-        this.name = name;
         this.apiKeyName = apiKeyName;
-        this.authProvidersConfig = authProvidersConfig;
+        validateConfig();
     }
 
     @Override
@@ -43,22 +46,16 @@ public class ApiKeyAuthenticationProvider implements AuthProvider {
     }
 
     private String getApiKey() {
-        return this.authProvidersConfig.auth().getOrDefault(name + "/api-key", "");
+        return getAuthConfigParam(API_KEY, "");
     }
 
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public List<OperationAuthInfo> operationsToFilter() {
-        return applyToOperations;
-    }
-
-    @Override
-    public AuthProvider addOperation(OperationAuthInfo operationAuthInfo) {
-        this.applyToOperations.add(operationAuthInfo);
-        return this;
+    private void validateConfig() {
+        if (isTokenPropagation()) {
+            throw new CodegenException(
+                    "Token propagation is not admitted for the OpenApi securitySchemes of \"type\": \"apiKey\"." +
+                            " A potential source of the problem might be that the configuration property "
+                            + getCanonicalAuthConfigPropertyName(TOKEN_PROPAGATION) +
+                            " was set with the value true in your application, please check your configuration.");
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BasicAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BasicAuthenticationProvider.java
@@ -1,34 +1,36 @@
 package io.quarkiverse.openapi.generator.providers;
 
+import static io.quarkiverse.openapi.generator.SpecItemAuthConfig.TOKEN_PROPAGATION;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.HttpHeaders;
+
+import io.quarkiverse.openapi.generator.CodegenConfig;
+import io.quarkiverse.openapi.generator.CodegenException;
 
 /**
  * Provider for Basic Authentication.
  * Username and password should be read by generated configuration properties, which is only known after openapi spec processing
  * during build time.
  */
-public class BasicAuthenticationProvider implements AuthProvider {
+public class BasicAuthenticationProvider extends AbstractAuthProvider {
 
-    private final String name;
-    private final AuthProvidersConfig authProvidersConfig;
-    private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
+    private static final String USER_NAME = "username";
+    private static final String PASSWORD = "password";
 
-    public BasicAuthenticationProvider(final String name, final AuthProvidersConfig authProvidersConfig) {
-        this.authProvidersConfig = authProvidersConfig;
-        this.name = name;
+    public BasicAuthenticationProvider(final String openApiSpecId, String name, final CodegenConfig codegenConfig) {
+        super(openApiSpecId, name, codegenConfig);
+        validateConfig();
     }
 
     private String getUsername() {
-        return authProvidersConfig.auth().getOrDefault(name + "/username", "");
+        return getAuthConfigParam(USER_NAME, "");
     }
 
     private String getPassword() {
-        return authProvidersConfig.auth().getOrDefault(name + "/password", "");
+        return getAuthConfigParam(PASSWORD, "");
     }
 
     @Override
@@ -37,19 +39,14 @@ public class BasicAuthenticationProvider implements AuthProvider {
                 AuthUtils.basicAuthAccessToken(getUsername(), getPassword()));
     }
 
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public List<OperationAuthInfo> operationsToFilter() {
-        return applyToOperations;
-    }
-
-    @Override
-    public AuthProvider addOperation(OperationAuthInfo operationAuthInfo) {
-        this.applyToOperations.add(operationAuthInfo);
-        return this;
+    private void validateConfig() {
+        if (isTokenPropagation()) {
+            throw new CodegenException(
+                    "Token propagation is not admitted for the OpenApi securitySchemes of \"type\": \"http\", \"scheme\": \"basic\"."
+                            +
+                            " A potential source of the problem might be that the configuration property " +
+                            getCanonicalAuthConfigPropertyName(TOKEN_PROPAGATION) +
+                            " was set with the value true in your application, please check your configuration.");
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
@@ -1,53 +1,42 @@
 package io.quarkiverse.openapi.generator.providers;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.HttpHeaders;
+
+import io.quarkiverse.openapi.generator.CodegenConfig;
 
 /**
  * Provides bearer token authentication or any other valid scheme.
  *
  * @see <a href="https://swagger.io/docs/specification/authentication/bearer-authentication/">Bearer Authentication</a>
  */
-public class BearerAuthenticationProvider implements AuthProvider {
+public class BearerAuthenticationProvider extends AbstractAuthProvider {
 
-    private final String name;
+    private static final String BEARER_TOKEN_CONFIG_PROPERTY = "bearer-token";
+
     private final String scheme;
-    private final AuthProvidersConfig authProvidersConfig;
-    private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
 
-    public BearerAuthenticationProvider(final String name, final String scheme, final AuthProvidersConfig authProvidersConfig) {
-        this.authProvidersConfig = authProvidersConfig;
-        this.name = name;
+    public BearerAuthenticationProvider(final String openApiSpecId, final String name, final String scheme,
+            final CodegenConfig codegenConfig) {
+        super(openApiSpecId, name, codegenConfig);
         this.scheme = scheme;
     }
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
+        String bearerToken;
+        if (isTokenPropagation()) {
+            bearerToken = getTokenForPropagation(requestContext.getHeaders());
+        } else {
+            bearerToken = getBearerToken();
+        }
         requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION,
-                AuthUtils.authTokenOrBearer(this.scheme, this.getBearerToken()));
+                AuthUtils.authTokenOrBearer(this.scheme, bearerToken));
     }
 
     private String getBearerToken() {
-        return this.authProvidersConfig.auth().getOrDefault(name + "/bearer-token", "");
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public List<OperationAuthInfo> operationsToFilter() {
-        return applyToOperations;
-    }
-
-    @Override
-    public AuthProvider addOperation(OperationAuthInfo operationAuthInfo) {
-        this.applyToOperations.add(operationAuthInfo);
-        return this;
+        return getAuthConfigParam(BEARER_TOKEN_CONFIG_PROPERTY, "");
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
@@ -1,40 +1,63 @@
 package io.quarkiverse.openapi.generator.providers;
 
-import java.util.ArrayList;
-import java.util.List;
+import static io.quarkiverse.openapi.generator.SpecItemAuthConfig.TOKEN_PROPAGATION;
+
+import java.io.IOException;
 import java.util.Optional;
 
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkiverse.openapi.generator.CodegenConfig;
 import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 
-public class OAuth2AuthenticationProvider extends OidcClientRequestFilter implements AuthProvider {
+public class OAuth2AuthenticationProvider extends AbstractAuthProvider {
 
-    private final String clientId;
-    private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2AuthenticationProvider.class);
 
-    public OAuth2AuthenticationProvider(final String clientId) {
-        this.clientId = clientId;
+    private final OidcClientRequestFilter delegate;
+
+    public OAuth2AuthenticationProvider(final String openApiSpecId, final String name, final CodegenConfig codegenConfig) {
+        super(openApiSpecId, name, codegenConfig);
+        this.delegate = new OidcClientRequestFilterDelegate(name);
         // it's fine calling it here since this class will be created on `init()` method of the generated CompositeAuthenticationProvider
-        super.init();
+        delegate.init();
+        validateConfig();
     }
 
     @Override
-    protected Optional<String> clientId() {
-        return Optional.of(this.clientId);
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        if (isTokenPropagation()) {
+            String bearerToken = getTokenForPropagation(requestContext.getHeaders());
+            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, OidcConstants.BEARER_SCHEME + " " + bearerToken);
+        } else {
+            delegate.filter(requestContext);
+        }
     }
 
-    @Override
-    public String getName() {
-        return this.clientId;
+    private void validateConfig() {
+        if (isTokenPropagation()) {
+            LOGGER.warn("Token propagation was enabled for a the oauth2: {} securityScheme in the specification file: {}. " +
+                    "This configuration can be done by using the property: {} and is not necessary a problem if the configuration is intentional.",
+                    getName(), getOpenApiSpecId(), getCanonicalAuthConfigPropertyName(TOKEN_PROPAGATION));
+        }
     }
 
-    @Override
-    public List<OperationAuthInfo> operationsToFilter() {
-        return applyToOperations;
-    }
+    private static class OidcClientRequestFilterDelegate extends OidcClientRequestFilter {
 
-    @Override
-    public AuthProvider addOperation(OperationAuthInfo operationAuthInfo) {
-        this.applyToOperations.add(operationAuthInfo);
-        return this;
+        private final String clientId;
+
+        public OidcClientRequestFilterDelegate(String clientId) {
+            this.clientId = clientId;
+        }
+
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(this.clientId);
+        }
     }
 }


### PR DESCRIPTION
Hello @ricardozanini would you mind review this PR while I continue working on the tests and documentation updates?

Thanks!

**Description:**

This PR introduces the ability to enable the security token propagation for particular securityScheme present on the OpenApi specification files, and additional related configurations.

The intention is to facilitate these configurations by using Quarkus styled properties naming, at the same time the configurations can be done per specification file and per securityScheme on that file.

Given an OpenApi specification file **petstore.json** the prefix **quarkus.openapi-generator.petstore_json** must be used to configure particular settings for that file.

Below we can see some example configurations assuming that we have the following securitySchemes defined on the file. (the types where included on the names for simplicity)

  "**example-http-bearer**"
  "**example-http-basic**"
  "**example-oauth2**"
  "**example-api-ke**y"


```
# Bearer token configuration example for the "example-http-bearer" security scheme.
quarkus.openapi-generator.petstore_json.auth.example_http_bearer.bearer-token=ABCDEF

# Bearer token propagation example for the "example-http-bearer" security scheme.
# Configures the token propagation and the header attribute from where to read the token to be propagated.
quarkus.openapi-generator.petstore_json.auth.example_http_bearer.token-propagation=true
quarkus.openapi-generator.petstore_json.auth.example_http_bearer.header-name=User-Custom-Header

# Basic authentication example configuration for the "example-http-basic" securityScheme
quarkus.openapi-generator.petstore_json.auth.example_http_basic.username=USER1
quarkus.openapi-generator.petstore_json.auth.example_http_basic.password=USER1PASSWORD

# Oauth2 token propagation configuration example for the "example-oauth2" security scheme.
quarkus.openapi-generator.petstore_json.auth.example_oauth2.token-propagation=true

# ApiKey configuration example for the "example-api-key" security scheme.
quarkus.openapi-generator.petstore_json.auth.example_api_key.api-key=VWXYZ
```