### PR TITLE
Add property to remove JsonNullable import

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -55,6 +55,7 @@ public class OpenApiClientGeneratorWrapper {
         this.configurator.setOutputDir(outputDir.toString());
         this.configurator.addAdditionalProperty("quarkus-generator",
                 Collections.singletonMap("openApiSpecId", getSanitizedFileName(specFilePath)));
+        this.configurator.addAdditionalProperty("openApiNullable", false);
         this.generator = new DefaultGenerator();
     }
 


### PR DESCRIPTION
The openApiNullable property controls the use of JsonNullable in the templates, and by consequence in generated classes. Since in this generator we are using our own templates that make no use of the JsonNullable wrapper but the property is not set, we are getting an extra import that is unused but breaks compilation if you don't have the needed dependency in your project. This commit fixes this by hardcoding this property to false.

This fixes the problem that originated https://github.com/quarkiverse/quarkus-openapi-generator/issues/66.