### PR TITLE
Add @ApplicationScoped to generated api to allow mocking api for testing

### DIFF
--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -20,6 +20,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import io.quarkiverse.openapi.generator.annotations.GeneratedClass;
 import io.quarkiverse.openapi.generator.annotations.GeneratedMethod;
 import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
@@ -37,6 +39,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 @RegisterProvider(CompositeAuthenticationProvider.class)
 @RegisterClientHeaders(AuthenticationPropagationHeadersFactory.class)
 {/if}
+@ApplicationScoped
 public interface {classname} {
 
     {#for op in operations.operation}


### PR DESCRIPTION
PR to fix issue #86.
Adding @ApplicationScoped annotation to generated API will allow us to mock it in unit test according to official Quarkus guidelines https://quarkus.io/blog/mocking/#using-injectmock