### PR TITLE
KOGITO-6458: Define default authentication method to be used by OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ pattern: `quarkus.openapi-generator.[filename].[security_scheme_name].auth.[auth
 
 > Tip: on production environments you will likely to use [HashiCorp Vault](https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html) or [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to provide this information for your application.
 
+If your OpenAPI specification file has `securitySchemes` definitions, but no [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) definitions, the generator can create these by default if the following property is defined:
+
+| Description          | Property Key                                                   | Value                                          |
+| -------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| Create security for the referenced security scheme | `quarkus.openapi-generator.codegen.default.security.scheme` | Name of the security scheme object definition, eg. `api_key` or `basic_auth` in the security scheme definitions above |
+
 ### Basic HTTP Authentication
 
 For Basic HTTP Authentication, these are the supported configurations:

--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ pattern: `quarkus.openapi-generator.[filename].[security_scheme_name].auth.[auth
 
 > Tip: on production environments you will likely to use [HashiCorp Vault](https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html) or [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to provide this information for your application.
 
-If your OpenAPI specification file has `securitySchemes` definitions, but no [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) definitions, the generator can create these by default if the following property is defined:
+If the OpenAPI specification file has `securitySchemes` definitions, but no [Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) definitions, the generator can be configured to create these by default. In this case, for all operations without a security requirement the default one will be created. Note that the property value needs to match the name of a security scheme object definition, eg. `api_key` or `basic_auth` in the `securitySchemes` list above.
 
-| Description          | Property Key                                                   | Value                                          |
+| Description          | Property Key                                                   | Example                                              |
 | -------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
-| Create security for the referenced security scheme | `quarkus.openapi-generator.codegen.default.security.scheme` | Name of the security scheme object definition, eg. `api_key` or `basic_auth` in the security scheme definitions above |
+| Create security for the referenced security scheme | `quarkus.openapi-generator.codegen.default.security.scheme` | `quarkus.openapi-generator.codegen.default.security.scheme=api_key` |
 
 ### Basic HTTP Authentication
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -17,6 +17,7 @@ public class CodegenConfig {
     public static final String API_PKG_SUFFIX = ".api";
     public static final String MODEL_PKG_SUFFIX = ".model";
     public static final String VERBOSE_PROPERTY_NAME = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".verbose";
+    public static final String DEFAULT_SECURITY_SCHEME = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".default.security.scheme";
     // package visibility for unit tests
     static final String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".spec.%s";
     private static final String BASE_PACKAGE_PROP_FORMAT = "%s.base-package";
@@ -33,6 +34,11 @@ public class CodegenConfig {
      */
     @ConfigItem(name = "verbose", defaultValue = "false")
     public boolean verbose;
+    /**
+     * Security type for which security constraints should be created automatically if not explicitly defined
+     */
+    @ConfigItem(name = "default.security.scheme", defaultValue = "none")
+    public String defaultSecurityScheme;
 
     public static String resolveApiPackage(final String basePackage) {
         return String.format("%s%s", basePackage, API_PKG_SUFFIX);

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -11,7 +11,9 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.Config;
+import org.openapitools.codegen.config.GlobalSettings;
 
+import io.quarkiverse.openapi.generator.deployment.CodegenConfig;
 import io.quarkiverse.openapi.generator.deployment.circuitbreaker.CircuitBreakerConfigurationParser;
 import io.quarkiverse.openapi.generator.deployment.wrapper.OpenApiClientGeneratorWrapper;
 import io.quarkus.bootstrap.prebuild.CodeGenException;
@@ -64,6 +66,8 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
     protected void generate(final Config config, final Path openApiFilePath, final Path outDir) {
         final String basePackage = getBasePackage(config, openApiFilePath);
         final Boolean verbose = config.getOptionalValue(VERBOSE_PROPERTY_NAME, Boolean.class).orElse(false);
+        GlobalSettings.setProperty(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME,
+                config.getOptionalValue(CodegenConfig.DEFAULT_SECURITY_SCHEME, String.class).orElse(""));
 
         final OpenApiClientGeneratorWrapper generator = new OpenApiClientGeneratorWrapper(
                 openApiFilePath.normalize(),

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -28,7 +28,10 @@ public class OpenApiClientGeneratorWrapper {
 
     public static final String VERBOSE = "verbose";
     private static final String ONCE_LOGGER = "org.openapitools.codegen.utils.oncelogger.enabled";
-
+    /**
+     * Security scheme for which to apply security constraints even if the OpenAPI definition has no security definition
+     */
+    public static final String DEFAULT_SECURITY_SCHEME = "defaultSecurityScheme";
     private final QuarkusCodegenConfigurator configurator;
     private final DefaultGenerator generator;
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -79,7 +79,7 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
         // add the default server url to the context
         additionalProperties.put(DEFAULT_SERVER_URL, URLPathUtils.getServerURL(this.openAPI, serverVariableOverrides()));
         additionalProperties.put(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME,
-                GlobalSettings.getProperty(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME, null));
+                GlobalSettings.getProperty(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME));
     }
 
     @Override

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -78,6 +78,8 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
         super.preprocessOpenAPI(openAPI);
         // add the default server url to the context
         additionalProperties.put(DEFAULT_SERVER_URL, URLPathUtils.getServerURL(this.openAPI, serverVariableOverrides()));
+        additionalProperties.put(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME,
+                GlobalSettings.getProperty(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME, null));
     }
 
     @Override

--- a/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
+++ b/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
@@ -46,6 +46,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});
@@ -64,6 +70,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});
@@ -82,6 +94,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});
@@ -101,6 +119,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});
@@ -119,6 +143,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});
@@ -137,6 +167,12 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
                 .build())
         {/if}
         {/for}
+        {#else if defaultSecurityScheme == auth.name}
+            .addOperation(OperationAuthInfo.builder()
+                .withPath("{api.contextPath}{api.commonPath}{op.path.orEmpty}")
+                .withId("{op.operationId}")
+                .withMethod("{op.httpMethod}")
+                .build())
         {/if}
         {/for}
         {/for});

--- a/integration-tests/example-project/src/main/openapi/open weather no security.yaml
+++ b/integration-tests/example-project/src/main/openapi/open weather no security.yaml
@@ -1,0 +1,318 @@
+openapi: "3.0.2"
+info:
+  title: "OpenWeatherMap API"
+  description: "Get the current weather, daily forecast for 16 days, and a three-hour-interval forecast for 5 days for your city. Helpful stats, graphics, and this day in history charts are available for your reference. Interactive maps show precipitation, clouds, pressure, wind around your location stations. Data is available in JSON, XML, or HTML format. **Note**: This sample Swagger file covers the `current` endpoint only from the OpenWeatherMap API. <br/><br/> **Note**: All parameters are optional, but you must select at least one parameter. Calling the API by city ID (using the `id` parameter) will provide the most precise location results."
+  version: "2.5"
+  termsOfService: "https://openweathermap.org/terms"
+  contact:
+    name: "OpenWeatherMap API"
+    url: "https://openweathermap.org/api"
+    email: "some_email@gmail.com"
+  license:
+    name: "CC Attribution-ShareAlike 4.0 (CC BY-SA 4.0)"
+    url: "https://openweathermap.org/price"
+
+servers:
+  - url: "https://api.openweathermap.org/data/2.5"
+
+paths:
+  /weather:
+    get:
+      tags:
+        - Current Weather Data
+      summary: "Call current weather data for one location"
+      description: "Access current weather data for any location on Earth including over 200,000 cities! Current weather is frequently updated based on global models and data from more than 40,000 weather stations."
+      operationId: CurrentWeatherData
+      parameters:
+        - $ref: '#/components/parameters/q'
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/lat'
+        - $ref: '#/components/parameters/lon'
+        - $ref: '#/components/parameters/zip'
+        - $ref: '#/components/parameters/units'
+        - $ref: '#/components/parameters/lang'
+        - $ref: '#/components/parameters/mode'
+
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200'
+        "404":
+          description: Not found response
+          content:
+            text/plain:
+              schema:
+                title: Weather not found
+                type: string
+                example: Not found
+
+tags:
+  - name: Current Weather Data
+    description: "Get current weather details"
+
+externalDocs:
+  description: API Documentation
+  url: https://openweathermap.org/api
+
+components:
+
+  parameters:
+    q:
+      name: q
+      in: query
+      description: "**City name**. *Example: London*. You can call by city name, or by city name and country code. The API responds with a list of results that match a searching word. For the query value, type the city name and optionally the country code divided by a comma; use ISO 3166 country codes."
+      schema:
+        type: string
+    id:
+      name: id
+      in: query
+      description: "**City ID**. *Example: `2172797`*. You can call by city ID. The API responds with the exact result. The List of city IDs can be downloaded [here](http://bulk.openweathermap.org/sample/). You can include multiple cities in this parameter &mdash; just separate them by commas. The limit of locations is 20. *Note: A single ID counts as a one API call. So, if you have city IDs, it's treated as 3 API calls.*"
+      schema:
+        type: string
+
+    lat:
+      name: lat
+      in: query
+      description: "**Latitude**. *Example: 35*. The latitude coordinate of the location of your interest. Must use with `lon`."
+      schema:
+        type: string
+
+    lon:
+      name: lon
+      in: query
+      description: "**Longitude**. *Example: 139*. Longitude coordinate of the location of your interest. Must use with `lat`."
+      schema:
+        type: string
+
+    zip:
+      name: zip
+      in: query
+      description: "**Zip code**. Search by zip code. *Example: 95050,us*. Please note that if the country is not specified, the search uses USA as a default."
+      schema:
+        type: string
+
+    units:
+      name: units
+      in: query
+      description: '**Units**. *Example: imperial*. Possible values: `standard`, `metric`, and `imperial`. When you do not use the `units` parameter, the format is `standard` by default.'
+      schema:
+        type: string
+        enum: [ standard, metric, imperial ]
+        default: "imperial"
+
+    lang:
+      name: lang
+      in: query
+      description: '**Language**. *Example: en*. You can use lang parameter to get the output in your language. We support the following languages that you can use with the corresponded lang values: Arabic - `ar`, Bulgarian - `bg`, Catalan - `ca`, Czech - `cz`, German - `de`, Greek - `el`, English - `en`, Persian (Farsi) - `fa`, Finnish - `fi`, French - `fr`, Galician - `gl`, Croatian - `hr`, Hungarian - `hu`, Italian - `it`, Japanese - `ja`, Korean - `kr`, Latvian - `la`, Lithuanian - `lt`, Macedonian - `mk`, Dutch - `nl`, Polish - `pl`, Portuguese - `pt`, Romanian - `ro`, Russian - `ru`, Swedish - `se`, Slovak - `sk`, Slovenian - `sl`, Spanish - `es`, Turkish - `tr`, Ukrainian - `ua`, Vietnamese - `vi`, Chinese Simplified - `zh_cn`, Chinese Traditional - `zh_tw`.'
+      schema:
+        type: string
+        enum: [ ar, bg, ca, cz, de, el, en, fa, fi, fr, gl, hr, hu, it, ja, kr, la, lt, mk, nl, pl, pt, ro, ru, se, sk, sl, es, tr, ua, vi, zh_cn, zh_tw ]
+        default: "en"
+
+    mode:
+      name: mode
+      in: query
+      description: "**Mode**. *Example: html*. Determines the format of the response. Possible values are `json`, `xml`, and `html`. If the mode parameter is empty, the format is `json` by default."
+      schema:
+        type: string
+        enum: [ json, xml, html ]
+        default: "json"
+
+  schemas:
+    "200":
+      title: Successful response
+      type: object
+      properties:
+        coord:
+          $ref: '#/components/schemas/Coord'
+        weather:
+          type: array
+          items:
+            $ref: '#/components/schemas/Weather'
+          description: (more info Weather condition codes)
+        base:
+          type: string
+          description: Internal parameter
+          example: cmc stations
+        main:
+          $ref: '#/components/schemas/Main'
+        visibility:
+          type: integer
+          description: Visibility, meter
+          example: 16093
+        wind:
+          $ref: '#/components/schemas/Wind'
+        clouds:
+          $ref: '#/components/schemas/Clouds'
+        rain:
+          $ref: '#/components/schemas/Rain'
+        snow:
+          $ref: '#/components/schemas/Snow'
+        dt:
+          type: integer
+          description: Time of data calculation, unix, UTC
+          format: int32
+          example: 1435658272
+        sys:
+          $ref: '#/components/schemas/Sys'
+        id:
+          type: integer
+          description: City ID
+          format: int32
+          example: 2172797
+        name:
+          type: string
+          example: Cairns
+        cod:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 200
+    Coord:
+      title: Coord
+      type: object
+      properties:
+        lon:
+          type: number
+          description: City geo location, longitude
+          example: 145.77000000000001
+        lat:
+          type: number
+          description: City geo location, latitude
+          example: -16.920000000000002
+    Weather:
+      title: Weather
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Weather condition id
+          format: int32
+          example: 803
+        main:
+          type: string
+          description: Group of weather parameters (Rain, Snow, Extreme etc.)
+          example: Clouds
+        description:
+          type: string
+          description: Weather condition within the group
+          example: broken clouds
+        icon:
+          type: string
+          description: Weather icon id
+          example: 04n
+    Main:
+      title: Main
+      type: object
+      properties:
+        temp:
+          type: number
+          description: 'Temperature. Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 293.25
+        pressure:
+          type: integer
+          description: Atmospheric pressure (on the sea level, if there is no sea_level or grnd_level data), hPa
+          format: int32
+          example: 1019
+        humidity:
+          type: integer
+          description: Humidity, %
+          format: int32
+          example: 83
+        temp_min:
+          type: number
+          description: 'Minimum temperature at the moment. This is deviation from current temp that is possible for large cities and megalopolises geographically expanded (use these parameter optionally). Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 289.81999999999999
+        temp_max:
+          type: number
+          description: 'Maximum temperature at the moment. This is deviation from current temp that is possible for large cities and megalopolises geographically expanded (use these parameter optionally). Unit Default: Kelvin, Metric: Celsius, Imperial: Fahrenheit.'
+          example: 295.37
+        sea_level:
+          type: number
+          description: Atmospheric pressure on the sea level, hPa
+          example: 984
+        grnd_level:
+          type: number
+          description: Atmospheric pressure on the ground level, hPa
+          example: 990
+    Wind:
+      title: Wind
+      type: object
+      properties:
+        speed:
+          type: number
+          description: 'Wind speed. Unit Default: meter/sec, Metric: meter/sec, Imperial: miles/hour.'
+          example: 5.0999999999999996
+        deg:
+          type: integer
+          description: Wind direction, degrees (meteorological)
+          format: int32
+          example: 150
+    Clouds:
+      title: Clouds
+      type: object
+      properties:
+        all:
+          type: integer
+          description: Cloudiness, %
+          format: int32
+          example: 75
+    Rain:
+      title: Rain
+      type: object
+      properties:
+        3h:
+          type: integer
+          description: Rain volume for the last 3 hours
+          format: int32
+          example: 3
+    Snow:
+      title: Snow
+      type: object
+      properties:
+        3h:
+          type: number
+          description: Snow volume for the last 3 hours
+          example: 6
+    Sys:
+      title: Sys
+      type: object
+      properties:
+        type:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 1
+        id:
+          type: integer
+          description: Internal parameter
+          format: int32
+          example: 8166
+        message:
+          type: number
+          description: Internal parameter
+          example: 0.0166
+        country:
+          type: string
+          description: Country code (GB, JP etc.)
+          example: AU
+        sunrise:
+          type: integer
+          description: Sunrise time, unix, UTC
+          format: int32
+          example: 1435610796
+        sunset:
+          type: integer
+          description: Sunset time, unix, UTC
+          format: int32
+          example: 1435650870
+
+  securitySchemes:
+    app_id:
+      type: apiKey
+      description: "API key to authorize requests. (If you don't have an API key, get one at https://openweathermap.org/. See https://idratherbewriting.com/learnapidoc/docapis_get_auth_keys.html for details.)"
+      name: appid
+      in: query

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -5,9 +5,14 @@ org.acme.openapi.security.auth.basic_auth/password=test
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
 quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
+quarkus.openapi-generator.codegen.spec.open_weather_no_security_yaml.base-package=org.acme.openapi.weathernosec
 # Authentication properties
 quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
+quarkus.openapi-generator.open_weather_no_security_yaml.auth.app_id.api-key=12345
 
+# KOGITO-6458 - generate auth bindings even if security definition is missing
+# Note: The property value is the name of an existing securityScheme in the spec file
+quarkus.openapi-generator.codegen.default.security.scheme=app_id
 
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/enabled=true
 org.acme.openapi.simple.api.DefaultApi/byeGet/CircuitBreaker/failOn = java.lang.IllegalArgumentException,java.lang.NullPointerException

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherDefaultSecurityTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/OpenWeatherDefaultSecurityTest.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.openapi.generator.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.acme.openapi.weathernosec.api.CurrentWeatherDataApi;
+import org.acme.openapi.weathernosec.model.Model200;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTestResource(WiremockOpenWeather.class)
+@QuarkusTest
+public class OpenWeatherDefaultSecurityTest {
+
+    // injected by quarkus test resource
+    WireMockServer openWeatherServer;
+
+    @ConfigProperty(name = "quarkus.openapi-generator.open_weather_no_security_yaml.auth.app_id.api-key")
+    String apiKey;
+
+    @ConfigProperty(name = WiremockOpenWeather.URL_NO_SEC_KEY)
+    String weatherUrl;
+
+    @RestClient
+    @Inject
+    CurrentWeatherDataApi weatherApi;
+
+    @Test
+    public void testGetWeatherByLatLon() {
+        final Model200 model = weatherApi.currentWeatherData("", "", "10", "-10", "", "", "", "");
+        assertEquals("Nowhere", model.getName());
+        assertNotNull(weatherUrl);
+        openWeatherServer.verify(WireMock.getRequestedFor(
+                WireMock.urlEqualTo("/data/2.5/weather?q=&id=&lat=10&lon=-10&zip=&units=&lang=&mode=&appid=" + apiKey)));
+    }
+
+}

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockOpenWeather.java
@@ -4,7 +4,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
-import java.util.Collections;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -16,6 +15,7 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
     private WireMockServer wireMockServer;
 
     public static final String URL_KEY = "quarkus.rest-client.open_weather_yaml.url";
+    public static final String URL_NO_SEC_KEY = "quarkus.rest-client.open_weather_no_security_yaml.url";
 
     @Override
     public Map<String, String> start() {
@@ -28,8 +28,8 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
                         .withHeader("Content-Type", "application/json")
                         .withBody(
                                 "{\"name\": \"Nowhere\"}")));
-        return Collections.singletonMap(URL_KEY,
-                wireMockServer.baseUrl().concat("/data/2.5"));
+        return Map.of(URL_KEY, wireMockServer.baseUrl().concat("/data/2.5"),
+                URL_NO_SEC_KEY, wireMockServer.baseUrl().concat("/data/2.5"));
     }
 
     @Override


### PR DESCRIPTION
The idea of this enhancement is to provide a configuration option that allows users to enforce security for all endpoints, even if the specification file is not explicitly defining these via the `security` element. Example: Assuming we have a spec file that contains the `securitySchemes` definition, but no `security` reference:

```
  securitySchemes:
    basic_auth:
      type: http
      scheme: basic
```

With this enhancement, the generator will create authentication bindings if the following property is defined:

```
quarkus.openapi-generator.codegen.default.security.scheme=basic_auth
```

**Note:** The property value needs to match the name of the `securityScheme` in the spec file.