### PR TITLE
Using full path as config key

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -3,6 +3,7 @@ package io.quarkiverse.openapi.generator.deployment;
 import java.nio.file.Path;
 import java.util.Map;
 
+import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiGeneratorOutputPaths;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -72,6 +73,7 @@ public class CodegenConfig {
     }
 
     public static String getSanitizedFileName(final Path openApiFilePath) {
-        return StringUtil.replaceNonAlphanumericByUnderscores(openApiFilePath.getFileName().toString());
+        return StringUtil
+                .replaceNonAlphanumericByUnderscores(OpenApiGeneratorOutputPaths.getRelativePath(openApiFilePath).toString());
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorJsonCodeGen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorJsonCodeGen.java
@@ -4,7 +4,7 @@ public class OpenApiGeneratorJsonCodeGen extends OpenApiGeneratorCodeGenBase {
 
     @Override
     public String providerId() {
-        return "open-api-json";
+        return OpenApiGeneratorOutputPaths.JSON_PATH;
     }
 
     @Override

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorOutputPaths.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorOutputPaths.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.openapi.generator.deployment.codegen;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+public class OpenApiGeneratorOutputPaths {
+
+    public static final String YAML_PATH = "open-api-yaml";
+    public static final String YML_PATH = "open-api-yml";
+    public static final String JSON_PATH = "open-api-json";
+    public static final String STREAM_PATH = "open-api-stream";
+
+    private static final Collection<String> rootPaths = Arrays.asList(STREAM_PATH);
+
+    public static Path getRelativePath(Path path) {
+        List<String> paths = new ArrayList<>();
+        Path currentPath = path;
+        while (currentPath != null && currentPath.getFileName() != null) {
+            if (rootPaths.contains(currentPath.getFileName().toString())) {
+                Iterator<String> iter = paths.iterator();
+                Path result = Path.of(iter.next());
+                while (iter.hasNext()) {
+                    result = result.resolve(iter.next());
+                }
+                return result;
+            } else {
+                paths.add(0, currentPath.getFileName().toString());
+                currentPath = currentPath.getParent();
+            }
+        }
+        return path.getFileName();
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorStreamCodeGen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorStreamCodeGen.java
@@ -42,7 +42,7 @@ public class OpenApiGeneratorStreamCodeGen extends OpenApiGeneratorCodeGenBase {
 
     @Override
     public String providerId() {
-        return "open-api-stream";
+        return OpenApiGeneratorOutputPaths.STREAM_PATH;
     }
 
     // unused by this CodeGenProvider since we rely on the input coming from ServiceLoaders

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorYamlCodeGen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorYamlCodeGen.java
@@ -4,7 +4,7 @@ public class OpenApiGeneratorYamlCodeGen extends OpenApiGeneratorCodeGenBase {
 
     @Override
     public String providerId() {
-        return "open-api-yaml";
+        return OpenApiGeneratorOutputPaths.YAML_PATH;
     }
 
     @Override

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorYmlCodeGen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorYmlCodeGen.java
@@ -4,7 +4,7 @@ public class OpenApiGeneratorYmlCodeGen extends OpenApiGeneratorCodeGenBase {
 
     @Override
     public String providerId() {
-        return "open-api-yml";
+        return OpenApiGeneratorOutputPaths.YML_PATH;
     }
 
     @Override

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiGeneratorOutputPaths;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.NamespaceResolver;
@@ -36,7 +37,7 @@ public class OpenApiNamespaceResolver implements NamespaceResolver {
     }
 
     public String parseUri(String uri) {
-        return Path.of(uri).getFileName().toString();
+        return OpenApiGeneratorOutputPaths.getRelativePath(Path.of(uri)).toString();
     }
 
     @Override

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
@@ -10,10 +10,17 @@ import org.junit.jupiter.api.Test;
 class CodegenConfigTest {
 
     @Test
-    void verifySpaceEncoding() {
+    void verifyStreamUri() {
         final String resolvedPrefix = CodegenConfig
                 .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/open-api-stream/luke/my test openapi.json"));
         assertEquals(String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "luke_my_test_openapi_json"), resolvedPrefix);
+    }
+
+    @Test
+    void verifySpaceEncoding() {
+        final String resolvedPrefix = CodegenConfig
+                .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/luke/my test openapi.json"));
+        assertEquals(String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"), resolvedPrefix);
     }
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/CodegenConfigTest.java
@@ -12,14 +12,14 @@ class CodegenConfigTest {
     @Test
     void verifySpaceEncoding() {
         final String resolvedPrefix = CodegenConfig
-                .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/luke/my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
+                .getBuildTimeSpecPropertyPrefix(Path.of("/home/myuser/open-api-stream/luke/my test openapi.json"));
+        assertEquals(String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "luke_my_test_openapi_json"), resolvedPrefix);
     }
 
     @Test
     void withSingleFileName() {
         final String resolvedPrefix = CodegenConfig.getBuildTimeSpecPropertyPrefix(Path.of("my test openapi.json"));
-        assertEquals(resolvedPrefix, String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"));
+        assertEquals(String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, "my_test_openapi_json"), resolvedPrefix);
     }
 
 }


### PR DESCRIPTION
For files generated from streams, relative spec file path rather than file name should be used for generating config key