### PR TITLE
Do not put a default url if there is not server url

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -1,19 +1,41 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.utils.ProcessUtils;
-import org.openapitools.codegen.utils.URLPathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.oas.models.servers.ServerVariables;
+
+import static org.openapitools.codegen.utils.OnceLogger.once;
 
 public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     private static final String AUTH_PACKAGE = "auth";
-    /**
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuarkusJavaClientCodegen.class);
+    public static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{([^\\}]+)\\}");
+
+    /*
      * Default server URL (the first one in the OpenAPI spec file servers definition.
      */
     private static final String DEFAULT_SERVER_URL = "defaultServerUrl";
@@ -73,11 +95,110 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
         return apiPackage().replace('.', File.separatorChar) + File.separator + AUTH_PACKAGE;
     }
 
+    public static Optional<URL> getServerURL(OpenAPI openAPI, Map<String, String> userDefinedVariables) {
+
+        final List<Server> servers = openAPI.getServers();
+        if (servers == null || servers.isEmpty()) {
+            once(LOGGER).warn("Server information seems not defined in the spec.");
+            return Optional.empty();
+        }
+        // TODO need a way to obtain all server URLs
+        return getServerURL(servers.get(0), userDefinedVariables);
+    }
+
+    private static Optional<URL> getServerURL(final Server server, final Map<String, String> userDefinedVariables) {
+        String url = server.getUrl();
+        ServerVariables variables = server.getVariables();
+        if (variables == null) {
+            variables = new ServerVariables();
+        }
+
+        Map<String, String> userVariables = userDefinedVariables == null ? new HashMap<>()
+                : Collections.unmodifiableMap(userDefinedVariables);
+
+        if (StringUtils.isNotBlank(url)) {
+            url = extractUrl(server, url, variables, userVariables);
+            url = sanitizeUrl(url);
+            try {
+                return Optional.of(new URL(url));
+            } catch (MalformedURLException e) {
+                once(LOGGER).warn("Not valid URL: {}", server.getUrl());
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String sanitizeUrl(String url) {
+        if (url != null) {
+            if (url.startsWith("//")) {
+                url = "http:" + url;
+                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+            } else if (url.startsWith("/")) {
+                once(LOGGER).info(
+                        "'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec.");
+            } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
+                // Add http scheme for urls without a scheme.
+                // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"
+                // 3.0 spec does not have an enumerated list of schemes
+                // This regex attempts to capture all schemes in IANA example schemes which
+                // can have alpha-numeric characters and [.+-]. Examples are here:
+                // https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+                url = "http://" + url;
+                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+            }
+        }
+        return url;
+    }
+
+    private static String extractUrl(Server server, String url, ServerVariables variables, Map<String, String> userVariables) {
+        Set<String> replacedVariables = new HashSet<>();
+        Matcher matcher = VARIABLE_PATTERN.matcher(url);
+        while (matcher.find()) {
+            if (!replacedVariables.contains(matcher.group())) {
+                String variableName = matcher.group(1);
+                ServerVariable variable = variables.get(variableName);
+                String replacement;
+                if (variable != null) {
+                    String defaultValue = variable.getDefault();
+                    List<String> enumValues = variable.getEnum() == null ? new ArrayList<>() : variable.getEnum();
+                    if (defaultValue == null && !enumValues.isEmpty()) {
+                        defaultValue = enumValues.get(0);
+                    } else if (defaultValue == null) {
+                        defaultValue = "";
+                    }
+
+                    replacement = userVariables.getOrDefault(variableName, defaultValue);
+
+                    if (!enumValues.isEmpty() && !enumValues.contains(replacement)) {
+                        once(LOGGER).warn("Variable override of '{}' is not listed in the enum of allowed values ({}).", replacement,
+                                StringUtils.join(enumValues, ","));
+                    }
+                } else {
+                    replacement = userVariables.getOrDefault(variableName, "");
+                }
+
+                if (StringUtils.isEmpty(replacement)) {
+                    replacement = "";
+                    once(LOGGER).warn(
+                            "No value found for variable '{}' in server definition '{}' and no user override specified, default to empty string.",
+                            variableName, server.getUrl());
+                }
+
+                url = url.replace(matcher.group(), replacement);
+                replacedVariables.add(matcher.group());
+                matcher = VARIABLE_PATTERN.matcher(url);
+            }
+        }
+        return url;
+    }
+
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
         super.preprocessOpenAPI(openAPI);
         // add the default server url to the context
-        additionalProperties.put(DEFAULT_SERVER_URL, URLPathUtils.getServerURL(this.openAPI, serverVariableOverrides()));
+        getServerURL(this.openAPI, serverVariableOverrides())
+                .ifPresent(url -> additionalProperties.put(DEFAULT_SERVER_URL, url));
         additionalProperties.put(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME,
                 GlobalSettings.getProperty(OpenApiClientGeneratorWrapper.DEFAULT_SECURITY_SCHEME));
     }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -1,40 +1,23 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.utils.ProcessUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.openapitools.codegen.utils.URLPathUtils;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.servers.ServerVariable;
-import io.swagger.v3.oas.models.servers.ServerVariables;
-
-import static org.openapitools.codegen.utils.OnceLogger.once;
 
 public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     private static final String AUTH_PACKAGE = "auth";
-    private static final Logger LOGGER = LoggerFactory.getLogger(QuarkusJavaClientCodegen.class);
-    public static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{([^\\}]+)\\}");
-
     /*
      * Default server URL (the first one in the OpenAPI spec file servers definition.
      */
@@ -96,101 +79,13 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
     }
 
     public static Optional<URL> getServerURL(OpenAPI openAPI, Map<String, String> userDefinedVariables) {
-
         final List<Server> servers = openAPI.getServers();
         if (servers == null || servers.isEmpty()) {
-            once(LOGGER).warn("Server information seems not defined in the spec.");
             return Optional.empty();
         }
-        // TODO need a way to obtain all server URLs
-        return getServerURL(servers.get(0), userDefinedVariables);
-    }
-
-    private static Optional<URL> getServerURL(final Server server, final Map<String, String> userDefinedVariables) {
-        String url = server.getUrl();
-        ServerVariables variables = server.getVariables();
-        if (variables == null) {
-            variables = new ServerVariables();
-        }
-
-        Map<String, String> userVariables = userDefinedVariables == null ? new HashMap<>()
-                : Collections.unmodifiableMap(userDefinedVariables);
-
-        if (StringUtils.isNotBlank(url)) {
-            url = extractUrl(server, url, variables, userVariables);
-            url = sanitizeUrl(url);
-            try {
-                return Optional.of(new URL(url));
-            } catch (MalformedURLException e) {
-                once(LOGGER).warn("Not valid URL: {}", server.getUrl());
-                return Optional.empty();
-            }
-        }
-        return Optional.empty();
-    }
-
-    private static String sanitizeUrl(String url) {
-        if (url != null) {
-            if (url.startsWith("//")) {
-                url = "http:" + url;
-                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
-            } else if (url.startsWith("/")) {
-                once(LOGGER).info(
-                        "'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec.");
-            } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
-                // Add http scheme for urls without a scheme.
-                // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"
-                // 3.0 spec does not have an enumerated list of schemes
-                // This regex attempts to capture all schemes in IANA example schemes which
-                // can have alpha-numeric characters and [.+-]. Examples are here:
-                // https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
-                url = "http://" + url;
-                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
-            }
-        }
-        return url;
-    }
-
-    private static String extractUrl(Server server, String url, ServerVariables variables, Map<String, String> userVariables) {
-        Set<String> replacedVariables = new HashSet<>();
-        Matcher matcher = VARIABLE_PATTERN.matcher(url);
-        while (matcher.find()) {
-            if (!replacedVariables.contains(matcher.group())) {
-                String variableName = matcher.group(1);
-                ServerVariable variable = variables.get(variableName);
-                String replacement;
-                if (variable != null) {
-                    String defaultValue = variable.getDefault();
-                    List<String> enumValues = variable.getEnum() == null ? new ArrayList<>() : variable.getEnum();
-                    if (defaultValue == null && !enumValues.isEmpty()) {
-                        defaultValue = enumValues.get(0);
-                    } else if (defaultValue == null) {
-                        defaultValue = "";
-                    }
-
-                    replacement = userVariables.getOrDefault(variableName, defaultValue);
-
-                    if (!enumValues.isEmpty() && !enumValues.contains(replacement)) {
-                        once(LOGGER).warn("Variable override of '{}' is not listed in the enum of allowed values ({}).", replacement,
-                                StringUtils.join(enumValues, ","));
-                    }
-                } else {
-                    replacement = userVariables.getOrDefault(variableName, "");
-                }
-
-                if (StringUtils.isEmpty(replacement)) {
-                    replacement = "";
-                    once(LOGGER).warn(
-                            "No value found for variable '{}' in server definition '{}' and no user override specified, default to empty string.",
-                            variableName, server.getUrl());
-                }
-
-                url = url.replace(matcher.group(), replacement);
-                replacedVariables.add(matcher.group());
-                matcher = VARIABLE_PATTERN.matcher(url);
-            }
-        }
-        return url;
+        final Server server = servers.get(0);
+        return server.getUrl().equals("/") ? Optional.empty()
+                : Optional.ofNullable(URLPathUtils.getServerURL(server, userDefinedVariables));
     }
 
     @Override

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -33,7 +33,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
   */
 {/if}
 @Path("{#if useAnnotatedBasePath}{contextPath}{/if}{commonPath}")
-@RegisterRestClient(baseUri="{defaultServerUrl}", configKey="{quarkus-generator.openApiSpecId}")
+@RegisterRestClient({#if defaultServerUrl}baseUri="{defaultServerUrl}",{/if} configKey="{quarkus-generator.openApiSpecId}")
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if hasAuthMethods}
 @RegisterProvider(CompositeAuthenticationProvider.class)

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/SimpleOpenApiTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/SimpleOpenApiTest.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.openapi.generator.it;
 
 import static io.quarkiverse.openapi.generator.it.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -8,10 +10,12 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -30,6 +34,12 @@ class SimpleOpenApiTest {
                 .content().isNotEmpty();
 
         CompilationUnit compilationUnit = StaticJavaParser.parse(generatedRestClient);
+
+        compilationUnit.findAll(ClassOrInterfaceDeclaration.class).stream()
+                .map(c -> c.getAnnotationByClass(RegisterRestClient.class)).filter(Optional::isPresent).map(Optional::get)
+                .map(a -> a.asNormalAnnotationExpr().getPairs())
+                .forEach(n -> n.forEach(p -> assertNotEquals("baseUri", p.getName())));
+
         List<MethodDeclaration> methodDeclarations = compilationUnit.findAll(MethodDeclaration.class);
         assertThat(methodDeclarations).isNotEmpty();
 


### PR DESCRIPTION
The goal of this PR is that if configuration is missing, the following message is printed

`Caused by: java.lang.IllegalArgumentException: Unable to determine the proper baseUrl/baseUri. Consider registering using @RegisterRestClient(baseUri="someuri"), @RegisterRestClient(configKey="orkey"), or by adding 'quarkus.rest-client."subtration_spec_yaml".url' or 'quarkus.rest-client."subtration_spec_yaml".uri' to your Quarkus configuration`

