### PR TITLE
Fix #135: Exclude deprecated operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,13 @@ file. By default, these attributes are generated. You can fine tune this behavio
 
 Use the property key `<base_package>.model.MyClass.generateDeprecated=false` to disable the deprecated attributes in the given model. For example `org.acme.weather.Country.generatedDeprecated=false`.
 
+## Skip Deprecated Attributes in API classes
+
+The client objects are classes generated in the `api` package. These classes might have [deprecated attributes](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9) in the Open API specification
+file. By default, these attributes are generated. You can fine tune this behavior if the deprecated attributes should not be generated.
+
+Use the property key `<base_package>.api.MyClass.generateDeprecated=false` to disable the deprecated attributes in the given API. For example `org.acme.openapi.simple.api.DefaultApi.generatedDeprecated=false`.
+
 ## Custom Register Providers for generated api
 
 In some cases, we need custom `RegisterProvider` for generated api, e.g. logging. You can define your own Providers in `application.properties` :

--- a/README.md
+++ b/README.md
@@ -541,12 +541,12 @@ file. By default, these attributes are generated. You can fine tune this behavio
 
 Use the property key `<base_package>.model.MyClass.generateDeprecated=false` to disable the deprecated attributes in the given model. For example `org.acme.weather.Country.generatedDeprecated=false`.
 
-## Skip Deprecated Attributes in API classes
+## Skip Deprecated Operations in API classes
 
-The client objects are classes generated in the `api` package. These classes might have [deprecated attributes](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9) in the Open API specification
-file. By default, these attributes are generated. You can fine tune this behavior if the deprecated attributes should not be generated.
+The client objects are classes generated in the `api` package. These classes might have [deprecated operations](https://spec.openapis.org/oas/v3.1.0#operation-object) in the Open API specification
+file. By default, these operations are generated. You can fine tune this behavior if the deprecated operations should not be generated.
 
-Use the property key `<base_package>.api.MyClass.generateDeprecated=false` to disable the deprecated attributes in the given API. For example `org.acme.openapi.simple.api.DefaultApi.generatedDeprecated=false`.
+Use the property key `<base_package>.api.MyClass.generateDeprecated=false` to disable the deprecated operations in the given API. For example `org.acme.openapi.simple.api.DefaultApi.generatedDeprecated=false`.
 
 ## Custom Register Providers for generated api
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ClassCodegenConfigParser.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ClassCodegenConfigParser.java
@@ -12,10 +12,10 @@ import java.util.stream.StreamSupport;
 import org.eclipse.microprofile.config.Config;
 
 /**
- * Extracts the Model codegen properties from a given {@link Config} reference.
+ * Extracts the codegen properties from a given {@link Config} reference.
  * These properties are then injected in the OpenAPI generator to tweak the code generation properties.
  */
-public final class ModelCodegenConfigParser {
+public final class ClassCodegenConfigParser {
 
     public static Map<String, Object> parse(final Config config, final String basePackage) {
         final List<String> modelProperties = filterPropertyNames(config.getPropertyNames(),

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ModelCodegenConfigParser.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/ModelCodegenConfigParser.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.resolveApiPackage;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.resolveModelPackage;
 
 import java.util.HashMap;
@@ -17,16 +18,19 @@ import org.eclipse.microprofile.config.Config;
 public final class ModelCodegenConfigParser {
 
     public static Map<String, Object> parse(final Config config, final String basePackage) {
-        final List<String> modelProperties = filterModelPropertyNames(config.getPropertyNames(),
+        final List<String> modelProperties = filterPropertyNames(config.getPropertyNames(),
                 resolveModelPackage(basePackage));
+        final List<String> apiProperties = filterPropertyNames(config.getPropertyNames(),
+                resolveApiPackage(basePackage));
+        modelProperties.addAll(apiProperties);
         final Map<String, Object> modelConfig = new HashMap<>();
         modelProperties.forEach(m -> modelConfig.put(m, config.getValue(m, String.class)));
         return modelConfig;
     }
 
-    private static List<String> filterModelPropertyNames(final Iterable<String> propertyNames, final String modelPackage) {
+    private static List<String> filterPropertyNames(final Iterable<String> propertyNames, final String findPackage) {
         return StreamSupport.stream(propertyNames.spliterator(), false)
-                .filter(propertyName -> propertyName.startsWith(modelPackage))
+                .filter(propertyName -> propertyName.startsWith(findPackage))
                 .collect(Collectors.toList());
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -78,7 +78,7 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
                 outDir,
                 verbose,
                 validateSpec)
-                        .withModelCodeGenConfig(ModelCodegenConfigParser.parse(config, basePackage))
+                        .withClassesCodeGenConfig(ClassCodegenConfigParser.parse(config, basePackage))
                         .withCircuitBreakerConfig(CircuitBreakerConfigurationParser.parse(
                                 config));
         config.getOptionalValue(getSkipFormModelPropertyName(openApiFilePath), String.class)

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
@@ -36,6 +36,18 @@ public class OpenApiNamespaceResolver implements NamespaceResolver {
         return Boolean.parseBoolean(codegenConfig.getOrDefault(key, "true").toString());
     }
 
+    /**
+     * @param pkg name of the given package
+     * @param classname name of the Model class
+     * @param codegenConfig Map with the model codegen properties
+     * @return true if the given model class should generate the deprecated attributes
+     */
+    public boolean genDeprecatedApiAttr(final String pkg, final String classname,
+            final HashMap<String, Object> codegenConfig) {
+        final String key = String.format("%s.%s.%s", pkg, classname, GENERATE_DEPRECATED_PROP);
+        return Boolean.parseBoolean(codegenConfig.getOrDefault(key, "true").toString());
+    }
+
     public String parseUri(String uri) {
         return OpenApiGeneratorOutputPaths.getRelativePath(Path.of(uri)).toString();
     }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -88,9 +88,9 @@ public class OpenApiClientGeneratorWrapper {
         return this;
     }
 
-    public OpenApiClientGeneratorWrapper withModelCodeGenConfig(final Map<String, Object> config) {
+    public OpenApiClientGeneratorWrapper withClassesCodeGenConfig(final Map<String, Object> config) {
         if (config != null) {
-            configurator.addAdditionalProperty("model-codegen", config);
+            configurator.addAdditionalProperty("classes-codegen", config);
         }
         return this;
     }

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -45,7 +45,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 public interface {classname} {
 
     {#for op in operations.operation}
-    {#if !op.deprecated || openapi:genDeprecatedApiAttr(package, classname, codegen)}
+    {#if !op.isDeprecated || openapi:genDeprecatedApiAttr(package, classname, model-codegen)}
     {#if op.summary}
     /**
      * {op.summary}

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -45,6 +45,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 public interface {classname} {
 
     {#for op in operations.operation}
+    {#if !op.deprecated || openapi:genDeprecatedApiAttr(package, classname, codegen)}
     {#if op.summary}
     /**
      * {op.summary}
@@ -89,6 +90,6 @@ public interface {classname} {
     {#include multipartFormdataPojo.qute param=op/}
     {/if}
 
-
+    {/if} {! check deprecated !}
     {/for}
 }

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -45,7 +45,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 public interface {classname} {
 
     {#for op in operations.operation}
-    {#if !op.isDeprecated || openapi:genDeprecatedApiAttr(package, classname, model-codegen)}
+    {#if !op.isDeprecated || openapi:genDeprecatedApiAttr(package, classname, classes-codegen)}
     {#if op.summary}
     /**
      * {op.summary}

--- a/deployment/src/main/resources/templates/model.qute
+++ b/deployment/src/main/resources/templates/model.qute
@@ -15,5 +15,5 @@ import javax.validation.Valid;
 {/if}
 {#for m in models}
 {#if m.model.isEnum}{#include enumOuterClass.qute e=m.model/}
-{#else}{#include pojo.qute m=m.model withXml=withXml codegen=model-codegen package=modelPackage/}{/if}
+{#else}{#include pojo.qute m=m.model withXml=withXml codegen=classes-codegen package=modelPackage/}{/if}
 {/for}

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -33,7 +33,7 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import io.quarkiverse.openapi.generator.annotations.GeneratedClass;
 import io.quarkiverse.openapi.generator.annotations.GeneratedMethod;
 import io.quarkiverse.openapi.generator.deployment.MockConfigUtils;
-import io.quarkiverse.openapi.generator.deployment.codegen.ModelCodegenConfigParser;
+import io.quarkiverse.openapi.generator.deployment.codegen.ClassCodegenConfigParser;
 
 public class OpenApiClientGeneratorWrapperTest {
 
@@ -100,10 +100,10 @@ public class OpenApiClientGeneratorWrapperTest {
 
     @Test
     void verifyDeprecatedFields() throws URISyntaxException, FileNotFoundException {
-        final Map<String, Object> codegenConfig = ModelCodegenConfigParser
+        final Map<String, Object> codegenConfig = ClassCodegenConfigParser
                 .parse(MockConfigUtils.getTestConfig("/codegen/application.properties"), "org.issue38");
         final List<File> generatedFiles = this.createGeneratorWrapper("issue-38.yaml")
-                .withModelCodeGenConfig(codegenConfig)
+                .withClassesCodeGenConfig(codegenConfig)
                 .generate("org.issue38");
 
         // we have two attributes that will be generated with the same name, one of them is deprecated
@@ -147,10 +147,10 @@ public class OpenApiClientGeneratorWrapperTest {
 
     @Test
     void verifyDeprecatedOperations() throws URISyntaxException, FileNotFoundException {
-        final Map<String, Object> codegenConfig = ModelCodegenConfigParser
+        final Map<String, Object> codegenConfig = ClassCodegenConfigParser
                 .parse(MockConfigUtils.getTestConfig("/deprecated/application.properties"), "org.deprecated");
         List<File> generatedFiles = this.createGeneratorWrapper("deprecated.json")
-                .withModelCodeGenConfig(codegenConfig)
+                .withClassesCodeGenConfig(codegenConfig)
                 .generate("org.deprecated");
         assertFalse(generatedFiles.isEmpty());
 

--- a/deployment/src/test/resources/deprecated/application.properties
+++ b/deployment/src/test/resources/deprecated/application.properties
@@ -1,0 +1,11 @@
+
+# Base package for our generated code
+quarkus.openapi-generator.codegen.spec.deprecated_json.base-package=org.deprecated
+
+# Should we generate deprecated operations for the given api?
+# By default, deprecated operations in model classes are generated
+# Using these properties you can fine tune the configuration for a given API
+# all the API classes are generated using the given package concatenated with ".api" and the classname
+# see the examples below
+ org.deprecated.api.DefaultApi.generateDeprecated=false
+

--- a/deployment/src/test/resources/openapi/deprecated.json
+++ b/deployment/src/test/resources/openapi/deprecated.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0-SNAPSHOT"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+
+    "/bye": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
OK this IF will skip generating the operation if its deprecated. 

```
 {#if !op.deprecated || openapi:genDeprecatedApiAttr(package, classname, codegen)}
```