### PR TITLE
Use original operationId in annotated GeneratedMethod

### DIFF
--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -65,7 +65,7 @@ public interface {classname} {
     {#if op.hasProduces}
     @Produces(\{{#for produce in op.produces}"{produce.mediaType}"{#if produce_hasNext}, {/if}{/for}\})
     {/if}
-    @GeneratedMethod ("{op.operationId}")
+    @GeneratedMethod ("{op.operationIdOriginal}")
     {#for cbClassConfig in circuit-breaker.orEmpty}{#if cbClassConfig.key == package + classname}
     {#for cbMethod in cbClassConfig.value.orEmpty}{#if cbMethod == op.nickname}
     @org.eclipse.microprofile.faulttolerance.CircuitBreaker

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -166,10 +166,22 @@ public class OpenApiClientGeneratorWrapperTest {
         List<MethodDeclaration> methodDeclarations = compilationUnit.findAll(MethodDeclaration.class);
         assertThat(methodDeclarations).isNotEmpty();
 
-        methodDeclarations.forEach(m -> assertThat(m.getAnnotationByClass(GeneratedMethod.class)).isPresent());
+        String byeMethodGet = "byeMethodGet";
+        String helloMethod = "helloMethod";
+        methodDeclarations.forEach(m -> {
+            Optional<AnnotationExpr> annotation = m.getAnnotationByClass(GeneratedMethod.class);
+            assertThat(annotation).isPresent();
+            if (byeMethodGet.equals(m.getNameAsString())) {
+                assertThat(annotation.get().asSingleMemberAnnotationExpr().getMemberValue().asStringLiteralExpr().getValue())
+                        .isEqualTo("Bye method_get");
+            } else if (helloMethod.equals(m.getNameAsString())) {
+                assertThat(annotation.get().asSingleMemberAnnotationExpr().getMemberValue().asStringLiteralExpr().getValue())
+                        .isEqualTo("helloMethod");
+            }
+        });
 
         Optional<MethodDeclaration> byeMethod = methodDeclarations.stream()
-                .filter(m -> m.getNameAsString().equals("byeGet"))
+                .filter(m -> m.getNameAsString().equals(byeMethodGet))
                 .findAny();
 
         assertThat(byeMethod).isNotEmpty();
@@ -179,7 +191,7 @@ public class OpenApiClientGeneratorWrapperTest {
                 .doesNotHaveAnyCircuitBreakerAttribute();
 
         methodDeclarations.stream()
-                .filter(m -> !m.getNameAsString().equals("byeGet"))
+                .filter(m -> !m.getNameAsString().equals(byeMethodGet))
                 .forEach(m -> assertThat(m).doesNotHaveCircuitBreakerAnnotation());
     }
 
@@ -299,7 +311,7 @@ public class OpenApiClientGeneratorWrapperTest {
     private List<File> generateRestClientFiles() throws URISyntaxException {
         OpenApiClientGeneratorWrapper generatorWrapper = createGeneratorWrapper("simple-openapi.json")
                 .withCircuitBreakerConfig(Map.of(
-                        "org.openapitools.client.api.DefaultApi", List.of("opThatDoesNotExist", "byeGet")));
+                        "org.openapitools.client.api.DefaultApi", List.of("opThatDoesNotExist", "byeMethodGet")));
 
         return generatorWrapper.generate("org.openapitools.client");
     }

--- a/deployment/src/test/resources/openapi/simple-openapi.json
+++ b/deployment/src/test/resources/openapi/simple-openapi.json
@@ -7,6 +7,7 @@
   "paths": {
     "/hello": {
       "get": {
+        "operationId": "helloMethod",
         "responses": {
           "200": {
             "description": "OK",
@@ -24,6 +25,7 @@
 
     "/bye": {
       "get": {
+        "operationId": "Bye method_get",
         "responses": {
           "200": {
             "description": "OK",


### PR DESCRIPTION
The generated annotation `@GeneratedMethod` currently uses as a value a sanitized name for the `operationId`. This is necessary for codegen because it is/can be used as java identifier, for instance, in method, variable or class name.  The issue with that, is that the reference to the operationId is lost. For example, an operationId of `Jobs doJob` gets translated to `jobsDoJob`, in a method with the same name. In the case of the annotation value, it makes sense that we keep the original String, because is not used for the codegen, it is a simple string. By using the original operationId, without sanitizing, it allows consumer applications to track back with an exact match to the `operationId` contained in the OpenAPI spec file.