### PR TITLE
Adding typemapping option to the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ In some cases, we need custom `RegisterProvider` for generated api, e.g. logging
 
 With the above configuration, the extension generates your Rest Clients with a code similar to the following:
 
-````java
+```java
 package org.acme.openapi.simple.api;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -584,11 +584,24 @@ public interface DefaultApi {
     @org.eclipse.microprofile.faulttolerance.CircuitBreaker
     public String byeGet();
 }
-````
+```
 
 ## Skip OpenAPI schema validation
 
 Use the property key `quarkus.openapi-generator.codegen.validateSpec=false` to disable validating the input specification file before code generation. By default, invalid specifications will result in an error.
+
+## Type and import mappings
+
+It's possible to remap types in the generated files. For example, instead of a `File` you can configure the code generator to use `InputStream` for all file upload parts of multipart request, or you could change all `UUID` types to `String`. You can configure this in your `application.properties` using the following configuration keys:
+
+| Description    | Property Key                                                                   | Example                                                                                                                                                                        |
+|----------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Type Mapping   | `quarkus.openapi-generator.codegen.spec.[filename].type-mappings.[oas_type]`   | `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=InputStream` will use `InputStream` as type for all objects of the OAS File type.                       |
+| Import Mapping | `quarkus.openapi-generator.codegen.spec.[filename].import-mappings.[oas_type]` | `quarkus.openapi-generator.codegen.spec.my_spec_yml.import-mappings.File=java.io.InputStream` will replace the default `import java.io.File` with `import java.io.InputStream` |
+
+Note that these configuration properties are maps where the keys are OAS data types and the values are Java types. 
+
+It's also possible to only use a type mapping with a fully qualified name, for instance `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=java.io.InputStream`. For more information and a list of all types see the OpenAPI generator documentation on [Type Mappings and Import Mappings](https://openapi-generator.tech/docs/usage/#type-mappings-and-import-mappings). (Note that you won't be able to change all types as some are hardcoded in the generator, e.g. the OAS type DateTime.)
 
 ## Known Limitations
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -25,6 +25,8 @@ public class CodegenConfig {
     private static final String BASE_PACKAGE_PROP_FORMAT = "%s.base-package";
     private static final String SKIP_FORM_MODEL_PROP_FORMAT = "%s.skip-form-model";
     private static final String ADDITIONAL_MODEL_TYPE_ANNOTATIONS_PROP_FORMAT = "%s.additional-model-type-annotations";
+    private static final String TYPE_MAPPINGS_PROP_FORMAT = "%s.type-mappings";
+    private static final String IMPORT_MAPPINGS_PROP_FORMAT = "%s.import-mappings";
 
     private static final String CUSTOM_REGISTER_PROVIDERS_FORMAT = "%s.custom-register-providers";
 
@@ -70,6 +72,14 @@ public class CodegenConfig {
 
     public static String getAdditionalModelTypeAnnotationsPropertyName(final Path openApiFilePath) {
         return String.format(ADDITIONAL_MODEL_TYPE_ANNOTATIONS_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
+    }
+
+    public static String getTypeMappingsPropertyName(final Path openApiFilePath) {
+        return String.format(TYPE_MAPPINGS_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
+    }
+
+    public static String getImportMappingsPropertyName(final Path openApiFilePath) {
+        return String.format(IMPORT_MAPPINGS_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
     }
 
     /**

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment;
 
+import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -26,4 +27,29 @@ public class SpecItemConfig {
     @ConfigItem(name = "skip-form-model")
     public Optional<Boolean> skipFormModel;
 
+    /**
+     * Type Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be used for a
+     * given OAS datatype (the keys of this map)
+     */
+    @ConfigItem(name = "type-mappings")
+    public Optional<Map<String, String>> typeMappings;
+
+    /**
+     * Import Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be
+     * imported when a given OAS datatype (the keys of this map) is used
+     */
+    @ConfigItem(name = "import-mappings")
+    public Optional<Map<String, String>> importMappings;
+
+    /**
+     * The specified annotations will be added to the generated model files
+     */
+    @ConfigItem(name = "additional-model-type-annotations")
+    public Optional<String> additionalModelTypeAnnotations;
+
+    /**
+     * Provider classes that should be registered on the generated rest client
+     */
+    @ConfigItem(name = "custom-register-providers")
+    public Optional<String> customRegisterProviders;
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -76,6 +76,7 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
                         .withClassesCodeGenConfig(ClassCodegenConfigParser.parse(config, basePackage))
                         .withCircuitBreakerConfig(CircuitBreakerConfigurationParser.parse(
                                 config));
+
         config.getOptionalValue(getSkipFormModelPropertyName(openApiFilePath), String.class)
                 .ifPresent(generator::withSkipFormModelConfig);
 
@@ -85,12 +86,11 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
         config.getOptionalValue(getCustomRegisterProvidersFormat(openApiFilePath), String.class)
                 .ifPresent(generator::withCustomRegisterProviders);
 
-        ((SmallRyeConfig) config) // Cast in order to load multiple values as a map
-                .getOptionalValues(getTypeMappingsPropertyName(openApiFilePath), String.class, String.class)
+        SmallRyeConfig smallRyeConfig = config.unwrap(SmallRyeConfig.class);
+        smallRyeConfig.getOptionalValues(getTypeMappingsPropertyName(openApiFilePath), String.class, String.class)
                 .ifPresent(generator::withTypeMappings);
 
-        ((SmallRyeConfig) config)
-                .getOptionalValues(getImportMappingsPropertyName(openApiFilePath), String.class, String.class)
+        smallRyeConfig.getOptionalValues(getImportMappingsPropertyName(openApiFilePath), String.class, String.class)
                 .ifPresent(generator::withImportMappings);
 
         generator.generate(basePackage);

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -1,12 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VALIDATE_SPEC_PROPERTY_NAME;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VERBOSE_PROPERTY_NAME;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getAdditionalModelTypeAnnotationsPropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getBasePackagePropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getCustomRegisterProvidersFormat;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSanitizedFileName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSkipFormModelPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,6 +16,7 @@ import io.quarkiverse.openapi.generator.deployment.wrapper.OpenApiClientGenerato
 import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.deployment.CodeGenContext;
 import io.quarkus.deployment.CodeGenProvider;
+import io.smallrye.config.SmallRyeConfig;
 
 /**
  * Code generation for OpenApi Client. Generates Java classes from OpenApi spec files located in src/main/openapi or
@@ -89,6 +84,14 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
 
         config.getOptionalValue(getCustomRegisterProvidersFormat(openApiFilePath), String.class)
                 .ifPresent(generator::withCustomRegisterProviders);
+
+        ((SmallRyeConfig) config) // Cast in order to load multiple values as a map
+                .getOptionalValues(getTypeMappingsPropertyName(openApiFilePath), String.class, String.class)
+                .ifPresent(generator::withTypeMappings);
+
+        ((SmallRyeConfig) config)
+                .getOptionalValues(getImportMappingsPropertyName(openApiFilePath), String.class, String.class)
+                .ifPresent(generator::withImportMappings);
 
         generator.generate(basePackage);
     }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -113,6 +113,11 @@ public class OpenApiClientGeneratorWrapper {
         return this;
     }
 
+    public OpenApiClientGeneratorWrapper withTypeMappings(final Map<String, String> typeMappings){
+        typeMappings.forEach(configurator::addTypeMapping);
+        return this;
+    }
+
     /**
      * Sets the global 'additionalModelTypeAnnotations' setting. If not set this setting will default to empty.
      *

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -113,8 +113,13 @@ public class OpenApiClientGeneratorWrapper {
         return this;
     }
 
-    public OpenApiClientGeneratorWrapper withTypeMappings(final Map<String, String> typeMappings){
+    public OpenApiClientGeneratorWrapper withTypeMappings(final Map<String, String> typeMappings) {
         typeMappings.forEach(configurator::addTypeMapping);
+        return this;
+    }
+
+    public OpenApiClientGeneratorWrapper withImportMappings(final Map<String, String> typeMappings) {
+        typeMappings.forEach(configurator::addImportMapping);
         return this;
     }
 

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 
@@ -282,11 +283,48 @@ public class OpenApiClientGeneratorWrapperTest {
                 .findAny();
         assertThat(multipartPojo).isNotEmpty();
 
-        assertThat(multipartPojo.orElseThrow().getFields()).hasSize(3);
-        multipartPojo.orElseThrow().getFields().forEach(field -> {
+        List<FieldDeclaration> fields = multipartPojo.orElseThrow().getFields();
+        assertThat(fields).hasSize(3);
+        fields.forEach(field -> {
             assertThat(field.getAnnotationByName("FormParam")).isPresent();
             assertThat(field.getAnnotationByName("PartType")).isPresent();
         });
+
+        Optional<VariableDeclarator> fileUploadVariable = findVariableByName(fields, "profileImage");
+        assertThat(fileUploadVariable.orElseThrow().getType().asString()).isEqualTo("File");
+    }
+
+    @Test
+    void verifyMultipartPojoGeneratesWithInputStreamWhenEnabled() throws URISyntaxException, FileNotFoundException {
+        final String inputStreamType = "java.io.InputStream";
+
+        List<File> generatedFiles = createGeneratorWrapper("multipart-openapi.yml")
+                .withSkipFormModelConfig("false")
+                .withTypeMappings(Map.of("File", inputStreamType))
+                .generate("org.acme");
+        assertFalse(generatedFiles.isEmpty());
+
+        Optional<File> file = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("UserProfileDataApi.java"))
+                .findAny();
+        assertThat(file).isNotEmpty();
+
+        CompilationUnit compilationUnit = StaticJavaParser.parse(file.orElseThrow());
+        Optional<ClassOrInterfaceDeclaration> multipartPojo = compilationUnit.findAll(ClassOrInterfaceDeclaration.class)
+                .stream()
+                .filter(c -> c.getNameAsString().equals("PostUserProfileDataMultipartForm"))
+                .findAny();
+        assertThat(multipartPojo).isNotEmpty();
+
+        List<FieldDeclaration> fields = multipartPojo.orElseThrow().getFields();
+        assertThat(fields).hasSize(3);
+        fields.forEach(field -> {
+            assertThat(field.getAnnotationByName("FormParam")).isPresent();
+            assertThat(field.getAnnotationByName("PartType")).isPresent();
+        });
+
+        Optional<VariableDeclarator> fileUploadVariable = findVariableByName(fields, "profileImage");
+        assertThat(fileUploadVariable.orElseThrow().getType().asString()).isEqualTo(inputStreamType);
     }
 
     @Test
@@ -366,5 +404,11 @@ public class OpenApiClientGeneratorWrapperTest {
 
     private String getTargetDir() throws URISyntaxException {
         return Paths.get(requireNonNull(getClass().getResource("/")).toURI()).getParent().toString();
+    }
+
+    private Optional<VariableDeclarator> findVariableByName(List<FieldDeclaration> fields, String name){
+        return fields.stream().map(field -> field.getVariable(0))
+                .filter((VariableDeclarator variable) -> name.equals(variable.getName().asString()))
+                .findFirst();
     }
 }

--- a/integration-tests/example-project/src/main/openapi/type-mappings-testing.yml
+++ b/integration-tests/example-project/src/main/openapi/type-mappings-testing.yml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: "Multipart form data API"
+  description: An api that uses multipart/form-data as request type
+  version: 1.0.0
+
+servers:
+  - url: "http://other-endpoint.com/api/v1"
+
+paths:
+  /type-mapping:
+    post:
+      tags:
+        - Type Mapping
+      operationId: PostTheData
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MultipartRequestBody'
+      responses:
+        "204":
+          description: "Data uploaded"
+        "400":
+          description: "Invalid ID supplied"
+
+components:
+  schemas:
+    SomeDateTime:
+      type: string
+      format: date-time
+    BinaryStringFile:
+      type: string
+      format: binary
+    UserId:
+      type: string
+      format: uuid
+
+    MultipartRequestBody:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UserId'
+        dateTime:
+          $ref: '#/components/schemas/SomeDateTime'
+        binaryStringFile:
+          $ref: '#/components/schemas/BinaryStringFile'
+
+

--- a/integration-tests/example-project/src/main/resources/application.properties
+++ b/integration-tests/example-project/src/main/resources/application.properties
@@ -29,3 +29,8 @@ quarkus.openapi-generator.codegen.spec.multipart_requests_yml.base-package=org.a
 quarkus.openapi-generator.codegen.spec.multipart_requests_yml.additional-model-type-annotations=@io.quarkus.runtime.annotations.RegisterForReflection
 # By default the openapi-generator doesn't generate models for multipart requests
 quarkus.openapi-generator.codegen.spec.multipart_requests_yml.skip-form-model=false
+
+quarkus.openapi-generator.codegen.spec.type_mappings_testing_yml.type-mappings.UUID=String
+quarkus.openapi-generator.codegen.spec.type_mappings_testing_yml.type-mappings.File=InputStream
+quarkus.openapi-generator.codegen.spec.type_mappings_testing_yml.import-mappings.File=java.io.InputStream
+quarkus.openapi-generator.codegen.spec.type_mappings_testing_yml.base-package=org.acme.openapi.typemapping

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/TypeAndImportMappingTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/TypeAndImportMappingTest.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 
 import org.acme.openapi.typemapping.api.TypeMappingApi;
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 
@@ -31,9 +30,6 @@ public class TypeAndImportMappingTest {
     @RestClient
     @Inject
     TypeMappingApi typeMappingApi;
-
-    @Inject
-    Config config;
 
     @Test
     public void canMapTypesAndImportToDifferentValues() {

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/TypeAndImportMappingTest.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/TypeAndImportMappingTest.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.openapi.generator.it;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
+
+import org.acme.openapi.typemapping.api.TypeMappingApi;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
+import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(WiremockTypeAndImportMapping.class)
+public class TypeAndImportMappingTest {
+
+    WireMockServer typeMappingServer;
+
+    @RestClient
+    @Inject
+    TypeMappingApi typeMappingApi;
+
+    @Inject
+    Config config;
+
+    @Test
+    public void canMapTypesAndImportToDifferentValues() {
+        final String testUuid = "00112233-4455-6677-8899-aabbccddeeff";
+        final InputStream testFile = new ByteArrayInputStream("Content of the file".getBytes(StandardCharsets.UTF_8));
+
+        TypeMappingApi.PostTheDataMultipartForm requestBody = new TypeMappingApi.PostTheDataMultipartForm();
+        requestBody.id = testUuid; // String instead of UUID
+        requestBody.binaryStringFile = testFile; // InputStream instead of File
+        // dateTime remains OffsetDateTime (as is default)
+        requestBody.dateTime = OffsetDateTime.of(2000, 2, 13, 4, 5, 6, 0, ZoneOffset.UTC);
+
+        typeMappingApi.postTheData(requestBody);
+
+        typeMappingServer.verify(postRequestedFor(urlEqualTo("/type-mapping"))
+                .withRequestBodyPart(new MultipartValuePatternBuilder()
+                        .withName("id")
+                        .withHeader(ContentTypeHeader.KEY, equalTo(MediaType.TEXT_PLAIN))
+                        .withBody(equalTo(testUuid)).build())
+                .withRequestBodyPart(new MultipartValuePatternBuilder()
+                        .withName("dateTime")
+                        .withHeader(ContentTypeHeader.KEY, equalTo(MediaType.TEXT_PLAIN))
+                        .withBody(equalTo("2000-02-13T04:05:06Z")).build())
+                .withRequestBodyPart(new MultipartValuePatternBuilder()
+                        .withName("binaryStringFile")
+                        .withHeader("Content-Disposition", containing("filename="))
+                        .withHeader(ContentTypeHeader.KEY, equalTo(MediaType.APPLICATION_OCTET_STREAM))
+                        .withBody(equalTo("Content of the file")).build()));
+    }
+}

--- a/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockTypeAndImportMapping.java
+++ b/integration-tests/example-project/src/test/java/io/quarkiverse/openapi/generator/it/WiremockTypeAndImportMapping.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.openapi.generator.it;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class WiremockTypeAndImportMapping implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(8890);
+        wireMockServer.start();
+
+        wireMockServer.stubFor(post(anyUrl())
+                .willReturn(aResponse().withStatus(204)));
+        return Collections.singletonMap("org.acme.openapi.typemapping.api.TypeMappingApi/mp-rest/url",
+                wireMockServer.baseUrl());
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer, f -> f.getName().equals("typeMappingServer"));
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+}


### PR DESCRIPTION
This PR will enable users to configure their own type mappings via the properties. For example, this allows users to use `InputStream` for their multipart file uploads (instead of the default `File`) as request in #118 .

NB: still a work in progress