### PR TITLE
Removing unnecessary Optional in SpecItemConfig for type and import mappings

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -32,14 +32,14 @@ public class SpecItemConfig {
      * given OAS datatype (the keys of this map)
      */
     @ConfigItem(name = "type-mappings")
-    public Optional<Map<String, String>> typeMappings;
+    public Map<String, String> typeMappings;
 
     /**
      * Import Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be
      * imported when a given OAS datatype (the keys of this map) is used
      */
     @ConfigItem(name = "import-mappings")
-    public Optional<Map<String, String>> importMappings;
+    public Map<String, String> importMappings;
 
     /**
      * The specified annotations will be added to the generated model files


### PR DESCRIPTION
As mentioned by @melloware in https://github.com/quarkiverse/quarkus-openapi-generator/issues/118#issuecomment-1286139685 Quarkus will generate unnecessary warnings when setting the `type-mappings` and `import-mappings` configuration items. For example setting this:
```
quarkus.openapi-generator.codegen.spec.documents_openapi_yml.type-mappings.File=InputStream
quarkus.openapi-generator.codegen.spec.documents_openapi_yml.import-mappings.File=java.io.InputStream
```
would cause the following warnings during code generation
```
[WARNING] [io.quarkus.config] Unrecognized configuration key "quarkus.openapi-generator.codegen.spec.documents_openapi_yml.type-mappings.File" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
[WARNING] [io.quarkus.config] Unrecognized configuration key "quarkus.openapi-generator.codegen.spec.documents_openapi_yml.import-mappings.File" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```

This cosmetic issue was caused by the type of the config items in `SpecItemConfig` being `Optional<Map<String, String>>`. This PR fixes this by changing the type to `Map<String, String>`. Whenever nothing is provided for any of these config items then the corresponding map will just be an empty map. 