### PR TITLE
Enabling custom data and datetime mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,14 +615,20 @@ Use the property key `quarkus.openapi-generator.codegen.validateSpec=false` to d
 
 It's possible to remap types in the generated files. For example, instead of a `File` you can configure the code generator to use `InputStream` for all file upload parts of multipart request, or you could change all `UUID` types to `String`. You can configure this in your `application.properties` using the following configuration keys:
 
-| Description    | Property Key                                                                   | Example                                                                                                                                                                        |
-|----------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Type Mapping   | `quarkus.openapi-generator.codegen.spec.[filename].type-mappings.[oas_type]`   | `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=InputStream` will use `InputStream` as type for all objects of the OAS File type.                       |
-| Import Mapping | `quarkus.openapi-generator.codegen.spec.[filename].import-mappings.[oas_type]` | `quarkus.openapi-generator.codegen.spec.my_spec_yml.import-mappings.File=java.io.InputStream` will replace the default `import java.io.File` with `import java.io.InputStream` |
+| Description    | Property Key                                                                 | Example                                                                                                                                                                        |
+|----------------|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Type Mapping   | `quarkus.openapi-generator.codegen.spec.[filename].type-mappings.[oas_type]` | `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=InputStream` will use `InputStream` as type for all objects of the OAS File type.                       |
+| Import Mapping | `quarkus.openapi-generator.codegen.spec.[filename].import-mappings.[type]`   | `quarkus.openapi-generator.codegen.spec.my_spec_yml.import-mappings.File=java.io.InputStream` will replace the default `import java.io.File` with `import java.io.InputStream` |
 
-Note that these configuration properties are maps where the keys are OAS data types and the values are Java types. 
+Note that these configuration properties are maps. For the type-mapping the keys are OAS data types and the values are Java types. 
 
-It's also possible to only use a type mapping with a fully qualified name, for instance `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=java.io.InputStream`. For more information and a list of all types see the OpenAPI generator documentation on [Type Mappings and Import Mappings](https://openapi-generator.tech/docs/usage/#type-mappings-and-import-mappings). (Note that you won't be able to change all types as some are hardcoded in the generator, e.g. the OAS type DateTime.)
+Another common example is needing `java.time.Instant` as type for date-time fields in your POJO classes. You can achieve with these settings:
+```properties
+quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.DateTime=Instant
+quarkus.openapi-generator.codegen.spec.my_spec_yml.import-mappings.Instant=java.time.Instant
+```
+
+It's also possible to only use a type mapping with a fully qualified name, for instance `quarkus.openapi-generator.codegen.spec.my_spec_yml.type-mappings.File=java.io.InputStream`. For more information and a list of all types see the OpenAPI generator documentation on [Type Mappings and Import Mappings](https://openapi-generator.tech/docs/usage/#type-mappings-and-import-mappings). 
 
 See the module [type-mapping](integration-tests/type-mapping) for an example of how to use this feature.
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -33,6 +33,12 @@ public class OpenApiClientGeneratorWrapper {
      * Security scheme for which to apply security constraints even if the OpenAPI definition has no security definition
      */
     public static final String DEFAULT_SECURITY_SCHEME = "defaultSecurityScheme";
+    private static final Map<String, String> defaultTypeMappings = Map.of(
+            "date", "LocalDate",
+            "DateTime", "OffsetDateTime");
+    private static final Map<String, String> defaultImportMappings = Map.of(
+            "LocalDate", "java.time.LocalDate",
+            "OffsetDateTime", "java.time.OffsetDateTime");
     private final QuarkusCodegenConfigurator configurator;
     private final DefaultGenerator generator;
 
@@ -62,6 +68,8 @@ public class OpenApiClientGeneratorWrapper {
                 Collections.singletonMap("openApiSpecId", getSanitizedFileName(specFilePath)));
         this.configurator.addAdditionalProperty("openApiNullable", false);
         this.configurator.setValidateSpec(validateSpec);
+        defaultTypeMappings.forEach(this.configurator::addTypeMapping);
+        defaultImportMappings.forEach(this.configurator::addImportMapping);
         this.generator = new DefaultGenerator();
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -70,6 +70,7 @@ public class OpenApiClientGeneratorWrapper {
         this.configurator.setValidateSpec(validateSpec);
         defaultTypeMappings.forEach(this.configurator::addTypeMapping);
         defaultImportMappings.forEach(this.configurator::addImportMapping);
+
         this.generator = new DefaultGenerator();
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -25,7 +25,6 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     public QuarkusJavaClientCodegen() {
         // immutable properties
-        this.setDateLibrary(JavaClientCodegen.JAVA8_MODE);
         this.setSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);
         this.setTemplateDir("templates");
     }

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -387,7 +387,7 @@ public class OpenApiClientGeneratorWrapperTest {
     }
 
     @Test
-    void shouldBeAbleToAddCustomeDateAndTimeMappings() throws URISyntaxException, FileNotFoundException {
+    void shouldBeAbleToAddCustomDateAndTimeMappings() throws URISyntaxException, FileNotFoundException {
         List<File> generatedFiles = createGeneratorWrapper("datetime-regression.yml")
                 .withTypeMappings(Map.of(
                         "date", "ThaiBuddhistDate",

--- a/deployment/src/test/resources/openapi/datetime-regression.yml
+++ b/deployment/src/test/resources/openapi/datetime-regression.yml
@@ -1,0 +1,64 @@
+openapi: 3.0.3
+info:
+  title: "Multipart form data API"
+  version: 1.0.0
+
+servers:
+  - url: "http://my.endpoint.com/api/v1"
+
+paths:
+  /dates-and-times:
+    get:
+      responses:
+        "200":
+          description: The response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeName'
+
+components:
+  schemas:
+    SomeName:
+      type: object
+      properties:
+        someDate:
+          type: string
+          format: date
+        someDateTime:
+          type: string
+          format: date-time
+        dateArray:
+          type: array
+          items:
+            type: string
+            format: date
+        dateTimeArray:
+          type: array
+          items:
+            type: string
+            format: date-time
+        dateSet:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: date
+        dateTimeSet:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: date-time
+        dateMap:
+          type: object
+          additionalProperties:
+            type: string
+            format: date
+        dateTimeMap:
+          type: object
+          additionalProperties:
+            type: string
+            format: date-time
+
+


### PR DESCRIPTION
This removes the default datelibrary `java8` and replaces it with the appropriate type and import mappings. The standard behaviour for the OAS `date` and `DateTime` types should not be changed. But now users can also override these mappings, for example:
```
type-mappings:
  "date" -> "ThaiBuddhistDate"
  "DateTime" -> "Instant"
import-mappings:
  "ThaiBuddhistDate" -> "java.time.chrono.ThaiBuddhistDate"
  "Instant" -> "java.time.Instant"
```