### PR TITLE
Control when path has not 'src' in it

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -140,7 +140,9 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
     }
 
     private String getInputBaseDirRelativeToModule(final Path sourceDir, final Config config) {
-        String baseModuleDirectory = sourceDir.toString().substring(0, sourceDir.toString().lastIndexOf("src"));
-        return config.getOptionalValue(INPUT_BASE_DIR, String.class).map(s -> baseModuleDirectory + s).orElse(null);
+        return config.getOptionalValue(INPUT_BASE_DIR, String.class).map(inputBaseDir -> {
+            int srcIndex = sourceDir.toString().lastIndexOf("src");
+            return srcIndex < 0 ? null : sourceDir.toString().substring(0, srcIndex) + inputBaseDir;
+        }).orElse(null);
     }
 }


### PR DESCRIPTION
Fixing issue #196 

An exception was being thrown when trying to substring a path not including 'src' in it. Now it's controlled that the index for the substring is valid before doing it.