### PR TITLE
Use dynamic port where possible in tests that use WireMock

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "2 0 * * 6"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ java ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/WiremockPetStore.java
+++ b/integration-tests/generation-tests/src/test/java/io/quarkiverse/openapi/generator/it/WiremockPetStore.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -17,7 +18,7 @@ public class WiremockPetStore implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8887);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(get(urlEqualTo("/pet/1234"))

--- a/integration-tests/multipart-request/src/test/java/io/quarkiverse/openapi/generator/it/multipart/request/WiremockMultipart.java
+++ b/integration-tests/multipart-request/src/test/java/io/quarkiverse/openapi/generator/it/multipart/request/WiremockMultipart.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -17,7 +18,7 @@ public class WiremockMultipart implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8889);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(post(anyUrl())

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/WiremockOpenWeather.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/WiremockOpenWeather.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -19,7 +20,7 @@ public class WiremockOpenWeather implements QuarkusTestResourceLifecycleManager 
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8888);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(get(urlPathEqualTo("/data/2.5/weather"))

--- a/integration-tests/skip-validation/src/test/java/io/quarkiverse/openapi/generator/it/WiremockAWX.java
+++ b/integration-tests/skip-validation/src/test/java/io/quarkiverse/openapi/generator/it/WiremockAWX.java
@@ -8,6 +8,7 @@ import static java.util.Collections.singletonMap;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -19,7 +20,7 @@ public class WiremockAWX implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8890);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
         wireMockServer.stubFor(post(urlPathEqualTo("/api/v2/job_templates/7/launch/"))
                 .willReturn(aResponse().withStatus(200)));

--- a/integration-tests/type-mapping/src/test/java/io/quarkiverse/openapi/generator/it/type/mapping/WiremockTypeAndImportMapping.java
+++ b/integration-tests/type-mapping/src/test/java/io/quarkiverse/openapi/generator/it/type/mapping/WiremockTypeAndImportMapping.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -15,7 +16,7 @@ public class WiremockTypeAndImportMapping implements QuarkusTestResourceLifecycl
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer(8890);
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(post(anyUrl())


### PR DESCRIPTION
Why?
Actually, the implementation of the tests using fixed ports in WireMock can lead to flaky tests.

Solution provided:
Replace the fixed ports with dynamic ones.

Closes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/180