### PR TITLE
Added quarkus2 branch to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "main/quarkus2"
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/209