### PR TITLE
Fixed issue that prevented the app from starting when "base-package" property was not set (#221)

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -19,7 +19,7 @@ public class SpecItemConfig {
      * Base package for where the generated code for the given OpenAPI specification will be added.
      */
     @ConfigItem(name = "base-package")
-    public String basePackage;
+    public Optional<String> basePackage;
 
     /**
      * Whether to skip the generation of models for form parameters


### PR DESCRIPTION
Signed-off-by: Helber Belmiro <helber.belmiro@gmail.com>

Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/221