### PR TITLE
Dependabot configuration changed to act only on main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "main/quarkus2"
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/227