### PR TITLE
Dependabot configuration changed to act only on main branch (#228)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "main/quarkus2"
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"


### PR DESCRIPTION
Backport of: https://github.com/quarkiverse/quarkus-openapi-generator/pull/228