### PR TITLE
Bump assertj-core from 3.23.1 to 3.24.1 (#229)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <quarkus.version>2.15.3.Final</quarkus.version>
 
     <version.com.github.javaparser>3.24.9</version.com.github.javaparser>
-    <version.org.assertj>3.23.1</version.org.assertj>
+    <version.org.assertj>3.24.1</version.org.assertj>
     <version.org.eclipse.microprofile.fault-tolerance>4.0.2</version.org.eclipse.microprofile.fault-tolerance>
     <version.com.github.tomakehurst>2.35.0</version.com.github.tomakehurst>
   </properties>


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/229