### PR TITLE
Bump javaparser-core from 3.24.9 to 3.24.10 (#230)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>2.15.3.Final</quarkus.version>
 
-    <version.com.github.javaparser>3.24.9</version.com.github.javaparser>
+    <version.com.github.javaparser>3.24.10</version.com.github.javaparser>
     <version.org.assertj>3.24.1</version.org.assertj>
     <version.org.eclipse.microprofile.fault-tolerance>4.0.2</version.org.eclipse.microprofile.fault-tolerance>
     <version.com.github.tomakehurst>2.35.0</version.com.github.tomakehurst>


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/230