### PR TITLE
Add missing description (#246)

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -8,6 +8,7 @@
   </parent>
   <artifactId>quarkus-openapi-generator</artifactId>
   <name>Quarkus - Openapi Generator - Runtime</name>
+  <description>Generation of Rest Clients based on OpenAPI specification files</description>
   <dependencies>
     <!-- Quarkus -->
     <dependency>


### PR DESCRIPTION
This is necessary to display the proper description in the tooling

Backport of: https://github.com/quarkiverse/quarkus-openapi-generator/pull/246