### PR TITLE
Changed oauth2AuthenticationProvider.qute to not be generated

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
@@ -28,7 +28,6 @@ public class QuteTemplatingEngineAdapter extends AbstractTemplatingEngineAdapter
             "queryParams.qute",
             "auth/compositeAuthenticationProvider.qute",
             "auth/headersFactory.qute",
-            "auth/oauth2AuthenticationProvider.qute",
             "multipartFormdataPojo.qute"
     };
     public final Engine engine;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -63,19 +63,6 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                     new SupportingFile("auth/headersFactory.qute",
                             authFileFolder(),
                             "AuthenticationPropagationHeadersFactory.java"));
-
-            Object quarkusGeneratorProperties = additionalProperties.get(QUARKUS_GENERATOR_NAME);
-
-            if (!(quarkusGeneratorProperties instanceof Map)) {
-                throw new IllegalStateException("Quarkus generator properties not found.");
-            }
-
-            Object openApiSpecId = ((Map<?, ?>) quarkusGeneratorProperties).get("openApiSpecId");
-
-            supportingFiles.add(
-                    new SupportingFile("auth/oauth2AuthenticationProvider.qute",
-                            authFileFolder(),
-                            openApiSpecId + "OAuth2AuthenticationProvider.java"));
         }
 
         apiTemplateFiles.clear();

--- a/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
+++ b/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
@@ -21,6 +21,8 @@ import io.quarkiverse.openapi.generator.providers.BearerAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.AbstractCompositeAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 
+import java.util.Optional;
+
 @Priority(Priorities.AUTHENTICATION)
 public class CompositeAuthenticationProvider extends AbstractCompositeAuthenticationProvider {
 
@@ -29,11 +31,18 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
 
     {#for auth in oauthMethods.orEmpty}
     @jakarta.inject.Inject
-    {quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider oAuth2Provider{auth_index};
+    io.quarkiverse.openapi.generator.providers.OAuth2AuthenticationProvider oAuth2Provider{auth_index};
+
+    @jakarta.inject.Inject
+    OidcClientRequestFilterDelegateImpl{auth_index} oidcClientRequestFilterDelegate{auth_index};
     {/for}
 
     @PostConstruct
     public void init() {
+        {#for auth in oauthMethods.orEmpty}
+        oAuth2Provider{auth_index}.init(sanitizeAuthName("{auth.name}"), "{quarkus-generator.openApiSpecId}", oidcClientRequestFilterDelegate{auth_index});
+        {/for}
+
         {#for auth in httpBasicMethods.orEmpty}
         BasicAuthenticationProvider basicAuthProvider{auth_index} = new BasicAuthenticationProvider("{quarkus-generator.openApiSpecId}", sanitizeAuthName("{auth.name}"), generatorConfig);
         this.addAuthenticationProvider(basicAuthProvider{auth_index});
@@ -187,4 +196,16 @@ public class CompositeAuthenticationProvider extends AbstractCompositeAuthentica
         {/for}
     }
 
+    {#for auth in oauthMethods.orEmpty}
+    @jakarta.enterprise.context.Dependent
+    static class OidcClientRequestFilterDelegateImpl{auth_index} extends io.quarkus.oidc.client.filter.OidcClientRequestFilter implements io.quarkiverse.openapi.generator.providers.OAuth2AuthenticationProvider.OidcClientRequestFilterDelegate {
+
+        private final String clientId = io.quarkiverse.openapi.generator.OpenApiGeneratorConfig.getSanitizedSecuritySchemeName("{auth.name}");
+
+        @Override
+        protected Optional<String> clientId() {
+            return Optional.of(clientId);
+        }
+    }
+    {/for}
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthProvider.java
@@ -22,24 +22,31 @@ public abstract class AbstractAuthProvider implements AuthProvider {
     private static final String CANONICAL_AUTH_CONFIG_PROPERTY_NAME = "quarkus." +
             RUNTIME_TIME_CONFIG_PREFIX + ".%s.auth.%s.%s";
 
-    private final String openApiSpecId;
-    private final String name;
+    private String openApiSpecId;
+    private String name;
     private final OpenApiGeneratorConfig generatorConfig;
     private AuthConfig authConfig;
     private final List<OperationAuthInfo> applyToOperations = new ArrayList<>();
 
     protected AbstractAuthProvider() {
         // Required by CDI. Not supposed to be used.
-        openApiSpecId = null;
         name = null;
         generatorConfig = null;
     }
 
-    protected AbstractAuthProvider(String openApiSpecId, String name, OpenApiGeneratorConfig generatorConfig) {
-        this.openApiSpecId = openApiSpecId;
-        this.name = name;
+    protected AbstractAuthProvider(OpenApiGeneratorConfig generatorConfig) {
         this.generatorConfig = generatorConfig;
-        Optional<SpecItemConfig> specItemConfig = generatorConfig.getItemConfig(openApiSpecId);
+    }
+
+    protected void init(String name, String openApiSpecId) {
+        this.name = name;
+        setOpenApiSpecId(openApiSpecId);
+    }
+
+    private void setOpenApiSpecId(String openApiSpecId) {
+        this.openApiSpecId = openApiSpecId;
+        Optional<SpecItemConfig> specItemConfig = Objects.requireNonNull(generatorConfig, "generatorConfig can't be null.")
+                .getItemConfig(openApiSpecId);
         if (specItemConfig.isPresent()) {
             Optional<AuthsConfig> authsConfig = specItemConfig.get().getAuth();
             authsConfig.ifPresent(

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
@@ -24,7 +24,8 @@ public class ApiKeyAuthenticationProvider extends AbstractAuthProvider {
     public ApiKeyAuthenticationProvider(final String openApiSpecId, final String name, final ApiKeyIn apiKeyIn,
             final String apiKeyName,
             final OpenApiGeneratorConfig generatorConfig) {
-        super(openApiSpecId, name, generatorConfig);
+        super(generatorConfig);
+        init(name, openApiSpecId);
         this.apiKeyIn = apiKeyIn;
         this.apiKeyName = apiKeyName;
         validateConfig();

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BasicAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BasicAuthenticationProvider.java
@@ -21,7 +21,8 @@ public class BasicAuthenticationProvider extends AbstractAuthProvider {
     static final String PASSWORD = "password";
 
     public BasicAuthenticationProvider(final String openApiSpecId, String name, final OpenApiGeneratorConfig generatorConfig) {
-        super(openApiSpecId, name, generatorConfig);
+        super(generatorConfig);
+        init(name, openApiSpecId);
         validateConfig();
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
@@ -20,7 +20,8 @@ public class BearerAuthenticationProvider extends AbstractAuthProvider {
 
     public BearerAuthenticationProvider(final String openApiSpecId, final String name, final String scheme,
             final OpenApiGeneratorConfig generatorConfig) {
-        super(openApiSpecId, name, generatorConfig);
+        super(generatorConfig);
+        init(name, openApiSpecId);
         this.scheme = scheme;
     }
 

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
@@ -1,9 +1,8 @@
-package {apiPackage}.auth;
+package io.quarkiverse.openapi.generator.providers;
 
 import static io.quarkiverse.openapi.generator.AuthConfig.TOKEN_PROPAGATION;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -12,30 +11,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.openapi.generator.OpenApiGeneratorConfig;
-import io.quarkiverse.openapi.generator.providers.AbstractAuthProvider;
-import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
 @io.quarkus.arc.Priority(jakarta.ws.rs.Priorities.AUTHENTICATION)
-@jakarta.enterprise.context.ApplicationScoped
-public class {quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider extends AbstractAuthProvider {
+@jakarta.enterprise.context.Dependent
+public class OAuth2AuthenticationProvider extends AbstractAuthProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger({quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2AuthenticationProvider.class);
 
-    private static final String SCHEMA_NAME = "oauth";
+    private OidcClientRequestFilterDelegate delegate;
 
-    private final OidcClientRequestFilterDelegate delegate;
-
-    {quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider() {
+    @SuppressWarnings("unused")
+    OAuth2AuthenticationProvider() {
         // Required by CDI. Not supposed to be used.
         delegate = null;
     }
 
     @jakarta.inject.Inject
-    public {quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider(
-            final OpenApiGeneratorConfig generatorConfig, final OidcClientRequestFilterDelegate delegate) {
-        super("{quarkus-generator.openApiSpecId}", SCHEMA_NAME, generatorConfig);
+    public OAuth2AuthenticationProvider(final OpenApiGeneratorConfig generatorConfig) {
+        super(generatorConfig);
+    }
+
+    public void init(String name, String openApiSpecId, OidcClientRequestFilterDelegate delegate) {
         this.delegate = delegate;
+        super.init(name, openApiSpecId);
         validateConfig();
     }
 
@@ -58,12 +57,7 @@ public class {quarkus-generator.openApiSpecId}OAuth2AuthenticationProvider exten
         }
     }
 
-    @jakarta.enterprise.context.ApplicationScoped
-    static class OidcClientRequestFilterDelegate extends OidcClientRequestFilter {
-
-        @Override
-        protected Optional<String> clientId() {
-            return Optional.of(SCHEMA_NAME);
-        }
+    public interface OidcClientRequestFilterDelegate {
+        void filter(ClientRequestContext requestContext) throws IOException;
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/242

There's a tiny piece of code that still needs to be generated because of `clientId`: https://github.com/quarkiverse/quarkus-openapi-generator/pull/248/files#diff-1fa4a5b1488fae8e12f5730d80671494aee2bdff745d5f13df3911575b84a7b5R199-R210