### PR TITLE
Bump quarkus from 2.16.2.Final to 2.16.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>2.16.2.Final</quarkus.version>
+    <quarkus.version>2.16.3.Final</quarkus.version>
 
     <version.com.github.javaparser>3.25.0</version.com.github.javaparser>
     <version.org.assertj>3.24.2</version.org.assertj>


### PR DESCRIPTION
Closes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/260