### PR TITLE
getResource puts a leading slash before the disk name on Windows (#268)

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapterTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapterTest.java
@@ -19,11 +19,13 @@ public class QuteTemplatingEngineAdapterTest {
     @Test
     void checkTemplateGenerator() throws IOException {
         final String petstoreOpenApi = requireNonNull(this.getClass().getResource("/openapi/petstore-openapi.json")).getPath();
+        // getResource puts a leading slash before the disk name on Windows, thus we wrap it into a file object
+        final File petstoreOpenApiFile = new File(petstoreOpenApi);
         final DefaultGenerator generator = new DefaultGenerator();
         final CodegenConfigurator configurator = new QuarkusCodegenConfigurator();
-        final File apiFile = File.createTempFile("api", "java");
+        final File apiFile = File.createTempFile("api", ".java");
         apiFile.deleteOnExit();
-        configurator.setInputSpec(petstoreOpenApi);
+        configurator.setInputSpec(petstoreOpenApiFile.getAbsolutePath());
         generator.opts(configurator.toClientOptInput());
 
         final File writtenFile = generator.getTemplateProcessor().write(Collections.singletonMap("name", "Jack"), "hello.qute",


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/268