### PR TITLE
Replaced `io.quarkus.arc.Priority` with `jakarta.annotation.Priority`

### DIFF
--- a/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
+++ b/deployment/src/main/resources/templates/auth/compositeAuthenticationProvider.qute
@@ -4,7 +4,7 @@ import jakarta.inject.Inject;
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.Priorities;
 
-import io.quarkus.arc.Priority;
+import jakarta.annotation.Priority;
 
 import io.quarkiverse.openapi.generator.OpenApiGeneratorConfig;
 

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/OAuth2AuthenticationProvider.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import io.quarkiverse.openapi.generator.OpenApiGeneratorConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
-@io.quarkus.arc.Priority(jakarta.ws.rs.Priorities.AUTHENTICATION)
+@jakarta.annotation.Priority(jakarta.ws.rs.Priorities.AUTHENTICATION)
 @jakarta.enterprise.context.Dependent
 public class OAuth2AuthenticationProvider extends AbstractAuthProvider {
 


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/272