### PR TITLE
Replaced quarkus-bootstrap-maven-plugin with quarkus-extension-maven-plugin

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -66,7 +66,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
         <executions>
           <execution>


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/298