### PR TITLE
Bump quarkiverse-parent from 12 to 13 (#305)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>12</version>
+    <version>13</version>
   </parent>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-parent</artifactId>


### PR DESCRIPTION
Cherry-pick of https://github.com/quarkiverse/quarkus-openapi-generator/pull/305

Bumps [quarkiverse-parent](https://github.com/quarkiverse/quarkiverse-parent) from 12 to 13.
- [Release notes](https://github.com/quarkiverse/quarkiverse-parent/releases)
- [Commits](https://github.com/quarkiverse/quarkiverse-parent/commits)

---
updated-dependencies:
- dependency-name: io.quarkiverse:quarkiverse-parent dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 6366db103c0cd3b999ea03e2de76cb4790c86a4c)