### PR TITLE
Bump slf4j-ext from 2.0.3 to 2.0.7 (#307)

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.openapitools>6.4.0</version.org.openapitools>
-    <version.org.slf4j>2.0.3</version.org.slf4j>
+    <version.org.slf4j>2.0.7</version.org.slf4j>
     <version.com.github.jknack>4.3.1</version.com.github.jknack>
   </properties>
 


### PR DESCRIPTION
Cherry-pick of https://github.com/quarkiverse/quarkus-openapi-generator/pull/307

Bumps [slf4j-ext](https://github.com/qos-ch/slf4j) from 2.0.3 to 2.0.7.
- [Release notes](https://github.com/qos-ch/slf4j/releases)
- [Commits](https://github.com/qos-ch/slf4j/compare/v_2.0.3...v_2.0.7)

---
updated-dependencies:
- dependency-name: org.slf4j:slf4j-ext dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit c47795fff3193b7fd02f68c82a1675c07d72ebee)