### PR TITLE
Bump javaparser-core from 3.25.2 to 3.25.3 (#321)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>2.16.6.Final</quarkus.version>
 
-    <version.com.github.javaparser>3.25.2</version.com.github.javaparser>
+    <version.com.github.javaparser>3.25.3</version.com.github.javaparser>
     <version.org.assertj>3.24.2</version.org.assertj>
     <version.org.eclipse.microprofile.fault-tolerance>4.0.2</version.org.eclipse.microprofile.fault-tolerance>
     <version.com.github.tomakehurst>2.35.0</version.com.github.tomakehurst>


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/321

Bumps [javaparser-core](https://github.com/javaparser/javaparser) from 3.25.2 to 3.25.3.
- [Release notes](https://github.com/javaparser/javaparser/releases)
- [Changelog](https://github.com/javaparser/javaparser/blob/master/changelog.md)
- [Commits](https://github.com/javaparser/javaparser/compare/javaparser-parent-3.25.2...javaparser-parent-3.25.3)

---
updated-dependencies:
- dependency-name: com.github.javaparser:javaparser-core dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 91a404e149538da06e9aa7dfc1179be8c6f1c9c4)