### PR TITLE
#308 do not duplicate Authorization header, see https://github.com/quarkiverse/quarkus-openapi-generator/issues/308

### DIFF
--- a/integration-tests/security/src/main/openapi/fooopenapi.json
+++ b/integration-tests/security/src/main/openapi/fooopenapi.json
@@ -1,0 +1,93 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "More description about the API",
+        "version": "1.0.0",
+        "title": "Swagger API Doc"
+    },
+    "host": "api.foo.fr/api",
+    "basePath": "/",
+    "tags": [
+        {
+            "name": "foo-resource",
+            "description": "Foo Resource"
+        }
+    ],
+    "paths": {
+        "/foo/v2.0/foo": {
+            "get": {
+                "tags": [
+                    "foo-resource"
+                ],
+                "summary": "getFoos",
+                "operationId": "getFoosUsingGET",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "description": "Authorization",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "something",
+                        "in": "query",
+                        "description": "something int",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FooDTO"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "JWT": [
+                            "global"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "securityDefinitions": {
+        "JWT": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    },
+    "definitions": {
+        "FooDTO": {
+            "type": "object",
+            "properties": {               
+                "fubar": {
+                    "type": "string"
+                }             
+            },
+            "title": "FooDTO"
+        }
+
+    }
+}

--- a/integration-tests/security/src/main/resources/application.properties
+++ b/integration-tests/security/src/main/resources/application.properties
@@ -7,6 +7,9 @@ org.acme.openapi.security.auth.basic_auth/password=test
 quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
 quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
 
+quarkus.openapi-generator.codegen.spec.fooopenapi_json.base-package=org.acme.openapi.foo
+quarkus.openapi-generator.fooopenapi_json.auth.JWT.api-key=fooapikey
+
 # Authentication properties
 quarkus.openapi-generator.codegen.spec.open_weather_no_security_yaml.base-package=org.acme.openapi.weathernosec
 quarkus.openapi-generator.open_weather_no_security_yaml.auth.app_id.api-key=12345

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.openapi.generator.it.security;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.acme.openapi.foo.api.FooResourceApi;
+import org.acme.openapi.foo.model.FooDTO;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTestResource(WiremockFoo.class)
+@QuarkusTest
+public class AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest {
+
+    WireMockServer fooServer;
+
+    @RestClient
+    @Inject
+    FooResourceApi fooResourceApi;
+
+    @Test
+    public void testNoMultipleAuthorizationHeadersAreSent() {
+        List<FooDTO> foos = fooResourceApi.getFoosUsingGET("not the fooapikey",
+                123465L);
+        assertNotNull(foos);
+
+        RequestPatternBuilder builder = getRequestedFor(
+                urlEqualTo("/api/foo/v2.0/foo?something=123465"))
+                .withHeader("Authorization", equalTo("fooapikey"));
+        List<LoggedRequest> requestsWithAuthHeader = fooServer.findAll(builder);
+        assertEquals(1, requestsWithAuthHeader.size(), "more than one request");
+
+        LoggedRequest loggedRequest = requestsWithAuthHeader.get(0);
+        HttpHeaders httpHeaders = loggedRequest.getHeaders();
+        long authHeaderCount = httpHeaders.all().stream().filter(
+                httpHeader -> httpHeader.keyEquals("Authorization")).count();
+        assertEquals(1, authHeaderCount, "multiple Authorization headers found");
+    }
+}

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/WiremockFoo.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/WiremockFoo.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.openapi.generator.it.security;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class WiremockFoo implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    public static final String URL_KEY = "quarkus.rest-client.fooopenapi_json.url";
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        wireMockServer.stubFor(get(urlPathMatching("/api/foo(.+)"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"fubar\": \"hello\"}]")));
+        return Map.of(URL_KEY, wireMockServer.baseUrl().concat("/api"));
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer, f -> f.getName().equals("fooServer"));
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
@@ -8,6 +8,9 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.UriBuilder;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.quarkiverse.openapi.generator.OpenApiGeneratorConfig;
 import io.quarkiverse.openapi.generator.OpenApiGeneratorException;
 
@@ -15,6 +18,8 @@ import io.quarkiverse.openapi.generator.OpenApiGeneratorException;
  * Provider for API Key authentication.
  */
 public class ApiKeyAuthenticationProvider extends AbstractAuthProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiKeyAuthenticationProvider.class);
 
     static final String API_KEY = "api-key";
 
@@ -41,13 +46,17 @@ public class ApiKeyAuthenticationProvider extends AbstractAuthProvider {
                 requestContext.getCookies().put(apiKeyName, new Cookie(apiKeyName, getApiKey()));
                 break;
             case header:
-                requestContext.getHeaders().add(apiKeyName, getApiKey());
+                requestContext.getHeaders().putSingle(apiKeyName, getApiKey());
                 break;
         }
     }
 
     private String getApiKey() {
-        return getAuthConfigParam(API_KEY, "");
+        final String key = getAuthConfigParam(API_KEY, "");
+        if (key.isEmpty()) {
+            LOGGER.warn("configured " + API_KEY + " property (see application.properties) is empty. hint: configure it.");
+        }
+        return key;
     }
 
     private void validateConfig() {


### PR DESCRIPTION
Cherry-pick of: https://github.com/quarkiverse/quarkus-openapi-generator/pull/311

* #308 do not duplicate Authorization header, see https://github.com/quarkiverse/quarkus-openapi-generator/issues/308

* #308 add IT test

* #308 linter

* #308 use LoggedRequest case. remove comments.

* #308 count the Authorization headers

* #308 log if api-key is empty

* #308 fix isEmpty

---------

Co-authored-by: Laurent Perez <laurent.perez@itk.fr>
(cherry picked from commit dfedbabf3716ea6a906566c41840b38bce9e2b2e)