### PR TITLE
Add failing test for RESTEasy Reactive when using request bodies

### DIFF
--- a/integration-tests/beanparam/src/main/openapi/openapi.yaml
+++ b/integration-tests/beanparam/src/main/openapi/openapi.yaml
@@ -8,13 +8,13 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0
   version: "4.0.0"
 tags:
-  - name: GetTest
-    description: GetTest Controller
+  - name: BeanParamTest
+    description: BeanParam Test Controller
 paths:
   /get:
     get:
       tags:
-        - GetTest
+        - BeanParamTest
       summary: getTest
       operationId: getTest
       parameters:
@@ -38,8 +38,41 @@ paths:
         403:
           $ref: "#/components/responses/ForbiddenResponse"
       deprecated: false
+  /patch:
+    patch:
+      tags:
+        - BeanParamTest
+      summary: patchTest
+      operationId: patchTest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchRequestDto'
+      responses:
+        202:
+          description: Accepted
+        400:
+          $ref: "#/components/responses/ErrorResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenResponse"
+      deprecated: false
 components:
   schemas:
+    PatchRequestDto:
+      title: PatchRequest
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
+      required:
+        - name
     TestObj:
       title: Pageable
       type: object

--- a/integration-tests/beanparam/src/test/java/io/quarkiverse/openapi/generator/it/BeanParamOpenApiTest.java
+++ b/integration-tests/beanparam/src/test/java/io/quarkiverse/openapi/generator/it/BeanParamOpenApiTest.java
@@ -1,17 +1,18 @@
 package io.quarkiverse.openapi.generator.it;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
-import org.openapi.quarkus.openapi_yaml.api.GetTestApi;
+import org.openapi.quarkus.openapi_yaml.api.BeanParamTestApi;
+import org.openapi.quarkus.openapi_yaml.model.PatchRequestDto;
 import org.openapi.quarkus.openapi_yaml.model.ResponseDto;
 import org.openapi.quarkus.openapi_yaml.model.TestObj;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -22,19 +23,31 @@ class BeanParamOpenApiTest {
 
     @RestClient
     @Inject
-    GetTestApi api;
+    BeanParamTestApi api;
 
     WireMockServer wireMockServer;
 
     @Test
-    void apiIsBeingGenerated() {
+    void getRequestReceivesQueryParam() {
         TestObj model = new TestObj();
         model.size(42);
 
         ResponseDto responseDto = api.getTest(model, true);
         assertThat(responseDto.getMessage()).isEqualTo("Hello");
 
-        wireMockServer.verify(WireMock.getRequestedFor(
-                WireMock.urlEqualTo("/get?size=42&unpaged=true")));
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/get?size=42&unpaged=true")));
+    }
+
+    @Test
+    void patchRequestReceivesParamsAsBody() {
+        PatchRequestDto requestModel = new PatchRequestDto();
+        requestModel.setName("Max");
+        requestModel.setAge(42);
+
+        api.patchTest(requestModel);
+
+        wireMockServer.verify(patchRequestedFor(urlEqualTo("/patch"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(" { \"name\": \"Max\", \"age\": 42 }")));
     }
 }

--- a/integration-tests/beanparam/src/test/java/io/quarkiverse/openapi/generator/it/WiremockBeanParam.java
+++ b/integration-tests/beanparam/src/test/java/io/quarkiverse/openapi/generator/it/WiremockBeanParam.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.openapi.generator.it;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import java.util.Map;
 
@@ -28,6 +26,9 @@ public class WiremockBeanParam implements QuarkusTestResourceLifecycleManager {
                         .withHeader("Content-Type", "application/json")
                         .withBody(
                                 "{\"message\": \"Hello\"}")));
+
+        wireMockServer.stubFor(patch(urlPathEqualTo("/patch"))
+                .willReturn(aResponse().withStatus(202)));
 
         return Map.of(URL_KEY, wireMockServer.baseUrl());
     }


### PR DESCRIPTION
Adds a test that fails due to the request body types (here: PatchRequestDto) getting generated with @QueryParam annotations on each field. This results in PATCH (or POST) requests that have each field as a query param as part of the URL ("/patch?name=Max&age=42") instead of as part of a JSON body.

This currently fails **only** if run against RESTEasy Reactive Client. The legacy RESTEasy Classic Client generates the expected body. In both cases the source code generated by the OpenAPI Generator remains the same.

To my knowledge the unwanted behavior of RESTEasy Reactive is however to spec and the @QueryParam annotation should not be added to types used as RequestBody. Of course this means that one should never share types used both for query request parameters and request bodies.

I'm opening this PR as a showcase for issue #357. Feel free to close/delete if obsolete or not needed. 