### PR TITLE
client-headers-factory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Imagine that we have a `updatePet` operation defined in the `petstore.json` spec
 The code below shows a simple example of the usage of this operation in a user-programmed service.
 
 ## Headers propagation
-Custom headers propagation can be set via microprofile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`
+Custom headers propagation can be set via MicroProfile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`.
 In order to consider this configuration you must force @RegisterClientHeaders to use its default microprofile ClientHeadersFactory implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of ClientHeadersFactory.
 
 | Description  | Property Key                                                               | Example                                                                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ In order to consider this configuration you must force `@RegisterClientHeaders` 
 | -------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Bearer Token | `quarkus.openapi-generator.codegen.spec.[fileName].client-headers-factory` | `quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-headers-factory=org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl` |
 
-If `client-headers-factory` is set to `none` @RegisterClientHeaders will use its default implicit implementation as in example above.
+If `client-headers-factory` is set to `none` `@RegisterClientHeaders` will use its default implicit implementation as in the example above.
 
 If no option is set then default generated AuthenticationPropagationHeadersFactory class is used.
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The code below shows a simple example of the usage of this operation in a user-p
 
 ## Headers propagation
 Custom headers propagation can be set via MicroProfile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`.
-In order to consider this configuration you must force @RegisterClientHeaders to use its default microprofile ClientHeadersFactory implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of ClientHeadersFactory.
+In order to consider this configuration you must force `@RegisterClientHeaders` to use its default MicroProfile `ClientHeadersFactory` implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of `ClientHeadersFactory`.
 
 | Description  | Property Key                                                               | Example                                                                                                                                                    |
 | -------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ In order to consider this configuration you must force `@RegisterClientHeaders` 
 
 If `client-headers-factory` is set to `none` `@RegisterClientHeaders` will use its default implicit implementation as in the example above.
 
-If no option is set then default generated AuthenticationPropagationHeadersFactory class is used.
+If no option is set then default generated `AuthenticationPropagationHeadersFactory` class is used.
 
 ```java
 import org.acme.api.PetApi;

--- a/README.md
+++ b/README.md
@@ -337,18 +337,6 @@ Let's see how it works by following a simple example:
 Imagine that we have a `updatePet` operation defined in the `petstore.json` specification file and secured with the `petstore_auth` security scheme.
 The code below shows a simple example of the usage of this operation in a user-programmed service.
 
-## Headers propagation
-Custom headers propagation can be set via MicroProfile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`.
-In order to consider this configuration you must force `@RegisterClientHeaders` to use its default MicroProfile `ClientHeadersFactory` implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of `ClientHeadersFactory`.
-
-| Description  | Property Key                                                               | Example                                                                                                                                                    |
-| -------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Bearer Token | `quarkus.openapi-generator.codegen.spec.[fileName].client-headers-factory` | `quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-headers-factory=org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl` |
-
-If `client-headers-factory` is set to `none` `@RegisterClientHeaders` will use its default implicit implementation as in the example above.
-
-If no option is set then default generated `AuthenticationPropagationHeadersFactory` class is used.
-
 ```java
 import org.acme.api.PetApi;
 import org.acme.model.Pet;
@@ -423,6 +411,18 @@ The token propagation can be used with type "oauth2" or "bearer" security scheme
 | ------------------------------------------------------------------ | -------------------------------------------------------- |
 | `quarkus.openapi-generator.[filename].auth.[security_scheme_name].token-propagation=[true,false]` | `quarkus.openapi-generator.petstore_json.auth.petstore_auth.token-propagation=true`<br/>Enables the token propagation for all the operations that are secured with the `petstore_auth` scheme in the `petstore_json` file.
 | `quarkus.openapi-generator.[filename].auth.[security_scheme_name].header-name=[http_header_name]` | `quarkus.openapi-generator.petstore_json.auth.petstore_auth.header-name=MyHeaderName`<br/>Says that the authorization token to propagate will be read from the HTTP header `MyHeaderName` instead of the standard HTTP `Authorization` header.
+
+## Headers propagation
+Custom headers propagation can be set via MicroProfile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`.
+In order to consider this configuration you must force `@RegisterClientHeaders` to use its default MicroProfile `ClientHeadersFactory` implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of `ClientHeadersFactory`.
+
+| Description  | Property Key                                                               | Example                                                                                                                                                    |
+| -------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Bearer Token | `quarkus.openapi-generator.codegen.spec.[fileName].client-headers-factory` | `quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-headers-factory=org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl` |
+
+If `client-headers-factory` is set to `none` `@RegisterClientHeaders` will use its default implicit implementation as in the example above.
+
+If no option is set then default generated `AuthenticationPropagationHeadersFactory` class is used.
 
 ## Circuit Breaker
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,18 @@ Let's see how it works by following a simple example:
 Imagine that we have a `updatePet` operation defined in the `petstore.json` specification file and secured with the `petstore_auth` security scheme.
 The code below shows a simple example of the usage of this operation in a user-programmed service.
 
+## Headers propagation
+Custom headers propagation can be set via microprofile configuration `org.eclipse.microprofile.rest.client.propagateHeaders`
+In order to consider this configuration you must force @RegisterClientHeaders to use its default microprofile ClientHeadersFactory implementation. Therefore there is an option `client-headers-factory` where you can set any implementation of ClientHeadersFactory.
+
+| Description  | Property Key                                                               | Example                                                                                                                                                    |
+| -------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Bearer Token | `quarkus.openapi-generator.codegen.spec.[fileName].client-headers-factory` | `quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-headers-factory=org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl` |
+
+If `client-headers-factory` is set to `none` @RegisterClientHeaders will use its default implicit implementation as in example above.
+
+If no option is set then default generated AuthenticationPropagationHeadersFactory class is used.
+
 ```java
 import org.acme.api.PetApi;
 import org.acme.model.Pet;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -34,7 +34,7 @@ public class CodegenConfig {
     private static final String CUSTOM_REGISTER_PROVIDERS_FORMAT = "%s.custom-register-providers";
 
     private static final String RETURN_RESPONSE_PROP_FORMAT = "%s.return-response";
-    private static final String CLIENT_HEADER_FACTORY_PROP_FORMAT = "%s.client-header-factory";
+    private static final String CLIENT_HEADER_FACTORY_PROP_FORMAT = "%s.client-headers-factory";
 
     /**
      * OpenAPI Spec details for codegen configuration.

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -34,6 +34,7 @@ public class CodegenConfig {
     private static final String CUSTOM_REGISTER_PROVIDERS_FORMAT = "%s.custom-register-providers";
 
     private static final String RETURN_RESPONSE_PROP_FORMAT = "%s.return-response";
+    private static final String CLIENT_HEADER_FACTORY_PROP_FORMAT = "%s.client-header-factory";
 
     /**
      * OpenAPI Spec details for codegen configuration.
@@ -112,5 +113,9 @@ public class CodegenConfig {
 
     public static String getReturnResponsePropertyName(final Path openApiFilePath) {
         return String.format(RETURN_RESPONSE_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
+    }
+
+    public static String getClientHeaderFactoryPropertyName(final Path openApiFilePath) {
+        return String.format(CLIENT_HEADER_FACTORY_PROP_FORMAT, getBuildTimeSpecPropertyPrefix(openApiFilePath));
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -60,6 +60,12 @@ public class SpecItemConfig {
     public Optional<Boolean> returnResponse;
 
     /**
+     * Defines if default client header factory should be used. Default is <code>false</code>.
+     */
+    @ConfigItem(name = "client-header-factory")
+    public Optional<String> clientHeaderFactory;
+
+    /**
      * Defines the normalizer options.
      */
     @ConfigItem(name = "open-api-normalizer")

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -60,10 +60,13 @@ public class SpecItemConfig {
     public Optional<Boolean> returnResponse;
 
     /**
-     * Defines if default client header factory should be used. Default is <code>false</code>.
+     * ClientHeaderFactory class that should be used in @RegisterClientHeaders.
+     * Full class name is expected
+     * By default generated AuthenticationPropagationHeadersFactory class is set.
+     * Can also be set to 'none' to use default microprofile implementation (DefaultClientHeadersFactoryImpl)
      */
-    @ConfigItem(name = "client-header-factory")
-    public Optional<String> clientHeaderFactory;
+    @ConfigItem(name = "client-headers-factory")
+    public Optional<String> clientHeadersFactory;
 
     /**
      * Defines the normalizer options.

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -1,10 +1,10 @@
 package io.quarkiverse.openapi.generator.deployment;
 
-import java.util.Map;
-import java.util.Optional;
-
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+
+import java.util.Map;
+import java.util.Optional;
 
 /*
  * Model for the configuration of this extension.
@@ -62,8 +62,10 @@ public class SpecItemConfig {
     /**
      * ClientHeaderFactory class that should be used in @RegisterClientHeaders.
      * Full class name is expected
-     * If option is not set then AuthenticationPropagationHeadersFactory is generated and used as value for @RegisterClientHeaders
-     * If set to 'none' then @RegisterClientHeaders will be generated without value and default microprofile implementation will be used
+     * If option is not set then AuthenticationPropagationHeadersFactory is generated and used as value
+     * for @RegisterClientHeaders
+     * If set to 'none' then @RegisterClientHeaders will be generated without value and default microprofile implementation will
+     * be used
      */
     @ConfigItem(name = "client-headers-factory")
     public Optional<String> clientHeadersFactory;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -1,10 +1,10 @@
 package io.quarkiverse.openapi.generator.deployment;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-
 import java.util.Map;
 import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
 
 /*
  * Model for the configuration of this extension.

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -62,8 +62,8 @@ public class SpecItemConfig {
     /**
      * ClientHeaderFactory class that should be used in @RegisterClientHeaders.
      * Full class name is expected
-     * By default generated AuthenticationPropagationHeadersFactory class is set.
-     * Can also be set to 'none' to use default microprofile implementation (DefaultClientHeadersFactoryImpl)
+     * If option is not set then AuthenticationPropagationHeadersFactory is generated and used as value for @RegisterClientHeaders
+     * If set to 'none' then @RegisterClientHeaders will be generated without value and default microprofile implementation will be used
      */
     @ConfigItem(name = "client-headers-factory")
     public Optional<String> clientHeadersFactory;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -1,6 +1,20 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.*;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.EXCLUDE_FILES;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.INCLUDE_FILES;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.INPUT_BASE_DIR;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VALIDATE_SPEC_PROPERTY_NAME;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VERBOSE_PROPERTY_NAME;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getAdditionalModelTypeAnnotationsPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getBasePackagePropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getClientHeaderFactoryPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getCustomRegisterProvidersFormat;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getImportMappingsPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getNormalizerPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getReturnResponsePropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSanitizedFileName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSkipFormModelPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getTypeMappingsPropertyName;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -1,19 +1,6 @@
 package io.quarkiverse.openapi.generator.deployment.codegen;
 
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.EXCLUDE_FILES;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.INCLUDE_FILES;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.INPUT_BASE_DIR;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VALIDATE_SPEC_PROPERTY_NAME;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.VERBOSE_PROPERTY_NAME;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getAdditionalModelTypeAnnotationsPropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getBasePackagePropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getCustomRegisterProvidersFormat;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getImportMappingsPropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getNormalizerPropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getReturnResponsePropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSanitizedFileName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getSkipFormModelPropertyName;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.getTypeMappingsPropertyName;
+import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -165,6 +152,10 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
 
         generator.withReturnResponse(config.getOptionalValue(getReturnResponsePropertyName(openApiFilePath), Boolean.class)
                 .orElse(false));
+
+        generator.withClientHeaderFactory(
+                config.getOptionalValue(getClientHeaderFactoryPropertyName(openApiFilePath), String.class)
+                        .orElse("default"));
 
         SmallRyeConfig smallRyeConfig = config.unwrap(SmallRyeConfig.class);
         smallRyeConfig.getOptionalValues(getTypeMappingsPropertyName(openApiFilePath), String.class, String.class)

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -135,7 +135,7 @@ public abstract class OpenApiClientGeneratorWrapper {
     }
 
     public OpenApiClientGeneratorWrapper withClientHeaderFactory(String clientHeaderFactory) {
-        configurator.addAdditionalProperty("client-header-factory", clientHeaderFactory);
+        configurator.addAdditionalProperty("client-headers-factory", clientHeaderFactory);
         return this;
     }
 

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -134,6 +134,11 @@ public abstract class OpenApiClientGeneratorWrapper {
         return this;
     }
 
+    public OpenApiClientGeneratorWrapper withClientHeaderFactory(String clientHeaderFactory) {
+        configurator.addAdditionalProperty("client-header-factory", clientHeaderFactory);
+        return this;
+    }
+
     public OpenApiClientGeneratorWrapper withImportMappings(final Map<String, String> typeMappings) {
         typeMappings.forEach(configurator::addImportMapping);
         return this;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -60,8 +60,8 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                             authFileFolder(),
                             "CompositeAuthenticationProvider.java"));
 
-            if (this.additionalProperties.get("client-header-factory") == null ||
-                    this.additionalProperties.get("client-header-factory").equals("default")) {
+            if (this.additionalProperties.get("client-headers-factory") == null ||
+                    this.additionalProperties.get("client-headers-factory").equals("default")) {
                 supportingFiles.add(
                         new SupportingFile("auth/headersFactory.qute",
                                 authFileFolder(),

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -59,10 +59,14 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                     new SupportingFile(AUTH_PACKAGE + "/compositeAuthenticationProvider.qute",
                             authFileFolder(),
                             "CompositeAuthenticationProvider.java"));
-            supportingFiles.add(
-                    new SupportingFile("auth/headersFactory.qute",
-                            authFileFolder(),
-                            "AuthenticationPropagationHeadersFactory.java"));
+
+            if (this.additionalProperties.get("client-header-factory") == null ||
+                    this.additionalProperties.get("client-header-factory").equals("default")) {
+                supportingFiles.add(
+                        new SupportingFile("auth/headersFactory.qute",
+                                authFileFolder(),
+                                "AuthenticationPropagationHeadersFactory.java"));
+            }
         }
 
         apiTemplateFiles.clear();

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -11,7 +11,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 {#if hasAuthMethods}
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import {package}.auth.CompositeAuthenticationProvider;
-{#if client-header-factory is 'default'}
+{#if client-headers-factory is 'default'}
 import {package}.auth.AuthenticationPropagationHeadersFactory;
 {/if}
 {/if}
@@ -40,13 +40,13 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if hasAuthMethods}
 @RegisterProvider(CompositeAuthenticationProvider.class)
-{#when client-header-factory}
+{#when client-headers-factory}
 {#is 'default'}
 @RegisterClientHeaders(AuthenticationPropagationHeadersFactory.class)
 {#is 'none'}
 @RegisterClientHeaders
 {#else}
-@RegisterClientHeaders({client-header-factory}.class)
+@RegisterClientHeaders({client-headers-factory}.class)
 {/when}
 {/if}
 {#for crpClassConfig in custom-register-providers.orEmpty}

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -11,7 +11,9 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 {#if hasAuthMethods}
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import {package}.auth.CompositeAuthenticationProvider;
+{#if client-header-factory is 'default'}
 import {package}.auth.AuthenticationPropagationHeadersFactory;
+{/if}
 {/if}
 
 import java.io.InputStream;
@@ -38,7 +40,14 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if hasAuthMethods}
 @RegisterProvider(CompositeAuthenticationProvider.class)
+{#when client-header-factory}
+{#is 'default'}
 @RegisterClientHeaders(AuthenticationPropagationHeadersFactory.class)
+{#is 'none'}
+@RegisterClientHeaders
+{#else}
+@RegisterClientHeaders({client-header-factory}.class)
+{/when}
 {/if}
 {#for crpClassConfig in custom-register-providers.orEmpty}
 @RegisterProvider({crpClassConfig}.class)

--- a/integration-tests/security/src/main/openapi/open weather v3.yaml
+++ b/integration-tests/security/src/main/openapi/open weather v3.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.2"
 info:
   title: "OpenWeatherMap API"
   description: "Get the current weather, daily forecast for 16 days, and a three-hour-interval forecast for 5 days for your city. Helpful stats, graphics, and this day in history charts are available for your reference. Interactive maps show precipitation, clouds, pressure, wind around your location stations. Data is available in JSON, XML, or HTML format. **Note**: This sample Swagger file covers the `current` endpoint only from the OpenWeatherMap API. <br/><br/> **Note**: All parameters are optional, but you must select at least one parameter. Calling the API by city ID (using the `id` parameter) will provide the most precise location results."
-  version: "2.5"
+  version: "3.5"
   termsOfService: "https://openweathermap.org/terms"
   contact:
     name: "OpenWeatherMap API"
@@ -13,13 +13,13 @@ info:
     url: "https://openweathermap.org/price"
 
 servers:
-  - url: "https://api.openweathermap.org/data/2.5"
+  - url: "https://api.openweathermap.org/data/3.5"
 
 paths:
   /weather:
     get:
       tags:
-        - Current Weather Data v2
+        - Current Weather Data v3
       summary: "Call current weather data for one location"
       description: "Access current weather data for any location on Earth including over 200,000 cities! Current weather is frequently updated based on global models and data from more than 40,000 weather stations."
       operationId: CurrentWeatherData

--- a/integration-tests/security/src/main/openapi/open weather v4.yaml
+++ b/integration-tests/security/src/main/openapi/open weather v4.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.2"
 info:
   title: "OpenWeatherMap API"
   description: "Get the current weather, daily forecast for 16 days, and a three-hour-interval forecast for 5 days for your city. Helpful stats, graphics, and this day in history charts are available for your reference. Interactive maps show precipitation, clouds, pressure, wind around your location stations. Data is available in JSON, XML, or HTML format. **Note**: This sample Swagger file covers the `current` endpoint only from the OpenWeatherMap API. <br/><br/> **Note**: All parameters are optional, but you must select at least one parameter. Calling the API by city ID (using the `id` parameter) will provide the most precise location results."
-  version: "2.5"
+  version: "4.5"
   termsOfService: "https://openweathermap.org/terms"
   contact:
     name: "OpenWeatherMap API"
@@ -13,13 +13,13 @@ info:
     url: "https://openweathermap.org/price"
 
 servers:
-  - url: "https://api.openweathermap.org/data/2.5"
+  - url: "https://api.openweathermap.org/data/4.5"
 
 paths:
   /weather:
     get:
       tags:
-        - Current Weather Data v2
+        - Current Weather Data v4
       summary: "Call current weather data for one location"
       description: "Access current weather data for any location on Earth including over 200,000 cities! Current weather is frequently updated based on global models and data from more than 40,000 weather stations."
       operationId: CurrentWeatherData

--- a/integration-tests/security/src/main/resources/application.properties
+++ b/integration-tests/security/src/main/resources/application.properties
@@ -4,9 +4,14 @@ org.acme.openapi.security.auth.basic_auth/password=test
 
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
-quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
-quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-header-factory=none
+quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather.v2
 quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
+
+quarkus.openapi-generator.codegen.spec.open_weather_v3_yaml.base-package=org.acme.openapi.weather.v3
+quarkus.openapi-generator.codegen.spec.open_weather_v3_yaml.client-headers-factory=none
+
+quarkus.openapi-generator.codegen.spec.open_weather_v4_yaml.base-package=org.acme.openapi.weather.v4
+quarkus.openapi-generator.codegen.spec.open_weather_v4_yaml.client-headers-factory=org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl
 
 quarkus.openapi-generator.codegen.spec.fooopenapi_json.base-package=org.acme.openapi.foo
 quarkus.openapi-generator.fooopenapi_json.auth.JWT.api-key=fooapikey

--- a/integration-tests/security/src/main/resources/application.properties
+++ b/integration-tests/security/src/main/resources/application.properties
@@ -5,6 +5,7 @@ org.acme.openapi.security.auth.basic_auth/password=test
 # since the file name has a space, we use the URI representation of this space here to not break the properties file
 # see the RFC3986 for more info https://datatracker.ietf.org/doc/html/rfc3986
 quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.openapi.weather
+quarkus.openapi-generator.codegen.spec.open_weather_yaml.client-header-factory=none
 quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
 
 quarkus.openapi-generator.codegen.spec.fooopenapi_json.base-package=org.acme.openapi.foo

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -48,11 +48,10 @@ public class OpenWeatherTest {
 
     @Test
     public void testClientHeadersFactory_defaultClientHeadersFactory() throws ClassNotFoundException {
-        Class currentWeatherDataV2Api = this.getClass().getClassLoader()
+        Class<?> currentWeatherDataV2Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v2.api.CurrentWeatherDataV2Api");
         assertTrue(currentWeatherDataV2Api.isAnnotationPresent(RegisterClientHeaders.class));
         RegisterClientHeaders annotation = currentWeatherDataV2Api.getAnnotation(RegisterClientHeaders.class);
-                .getAnnotation(RegisterClientHeaders.class);
         assertEquals(AuthenticationPropagationHeadersFactory.class, annotation.value());
     }
 
@@ -61,8 +60,7 @@ public class OpenWeatherTest {
         Class<?> currentWeatherDataV3Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v3.api.CurrentWeatherDataV3Api");
         assertTrue(currentWeatherDataV3Api.isAnnotationPresent(RegisterClientHeaders.class));
-        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV3Api
-                .getAnnotation(RegisterClientHeaders.class);
+        RegisterClientHeaders annotation =  currentWeatherDataV3Api.getAnnotation(RegisterClientHeaders.class);
         assertEquals(org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl.class, annotation.value());
     }
 
@@ -71,8 +69,7 @@ public class OpenWeatherTest {
         Class<?> currentWeatherDataV4Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v4.api.CurrentWeatherDataV4Api");
         assertTrue(currentWeatherDataV4Api.isAnnotationPresent(RegisterClientHeaders.class));
-        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV4Api
-                .getAnnotation(RegisterClientHeaders.class);
+        RegisterClientHeaders annotation = currentWeatherDataV4Api.getAnnotation(RegisterClientHeaders.class);
         assertEquals(org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl.class, annotation.value());
     }
 

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -60,7 +60,7 @@ public class OpenWeatherTest {
         Class<?> currentWeatherDataV3Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v3.api.CurrentWeatherDataV3Api");
         assertTrue(currentWeatherDataV3Api.isAnnotationPresent(RegisterClientHeaders.class));
-        RegisterClientHeaders annotation =  currentWeatherDataV3Api.getAnnotation(RegisterClientHeaders.class);
+        RegisterClientHeaders annotation = currentWeatherDataV3Api.getAnnotation(RegisterClientHeaders.class);
         assertEquals(org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl.class, annotation.value());
     }
 

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -68,7 +68,7 @@ public class OpenWeatherTest {
 
     @Test
     public void testClientHeadersFactory_customClientHeadersFactory() throws ClassNotFoundException {
-        Class currentWeatherDataV4Api = this.getClass().getClassLoader()
+        Class<?> currentWeatherDataV4Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v4.api.CurrentWeatherDataV4Api");
         assertTrue(currentWeatherDataV4Api.isAnnotationPresent(RegisterClientHeaders.class));
         RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV4Api

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -51,7 +51,7 @@ public class OpenWeatherTest {
         Class currentWeatherDataV2Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v2.api.CurrentWeatherDataV2Api");
         assertTrue(currentWeatherDataV2Api.isAnnotationPresent(RegisterClientHeaders.class));
-        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV2Api
+        RegisterClientHeaders annotation = currentWeatherDataV2Api.getAnnotation(RegisterClientHeaders.class);
                 .getAnnotation(RegisterClientHeaders.class);
         assertEquals(AuthenticationPropagationHeadersFactory.class, annotation.value());
     }

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -58,7 +58,7 @@ public class OpenWeatherTest {
 
     @Test
     public void testClientHeadersFactory_noneClientHeadersFactory() throws ClassNotFoundException {
-        Class currentWeatherDataV3Api = this.getClass().getClassLoader()
+        Class<?> currentWeatherDataV3Api = this.getClass().getClassLoader()
                 .loadClass("org.acme.openapi.weather.v3.api.CurrentWeatherDataV3Api");
         assertTrue(currentWeatherDataV3Api.isAnnotationPresent(RegisterClientHeaders.class));
         RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV3Api

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/OpenWeatherTest.java
@@ -2,12 +2,15 @@ package io.quarkiverse.openapi.generator.it.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.inject.Inject;
 
-import org.acme.openapi.weather.api.CurrentWeatherDataApi;
-import org.acme.openapi.weather.model.Model200;
+import org.acme.openapi.weather.v2.api.CurrentWeatherDataV2Api;
+import org.acme.openapi.weather.v2.api.auth.AuthenticationPropagationHeadersFactory;
+import org.acme.openapi.weather.v2.model.Model200;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +35,45 @@ public class OpenWeatherTest {
 
     @RestClient
     @Inject
-    CurrentWeatherDataApi weatherApi;
+    CurrentWeatherDataV2Api weatherApiv2;
 
     @Test
     public void testGetWeatherByLatLon() {
-        final Model200 model = weatherApi.currentWeatherData("", "", "10", "-10", "", "", "", "");
+        final Model200 model = weatherApiv2.currentWeatherData("", "", "10", "-10", "", "", "", "");
         assertEquals("Nowhere", model.getName());
         assertNotNull(weatherUrl);
         openWeatherServer.verify(WireMock.getRequestedFor(
                 WireMock.urlEqualTo("/data/2.5/weather?q=&id=&lat=10&lon=-10&zip=&units=&lang=&mode=&appid=" + apiKey)));
+    }
+
+    @Test
+    public void testClientHeadersFactory_defaultClientHeadersFactory() throws ClassNotFoundException {
+        Class currentWeatherDataV2Api = this.getClass().getClassLoader()
+                .loadClass("org.acme.openapi.weather.v2.api.CurrentWeatherDataV2Api");
+        assertTrue(currentWeatherDataV2Api.isAnnotationPresent(RegisterClientHeaders.class));
+        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV2Api
+                .getAnnotation(RegisterClientHeaders.class);
+        assertEquals(AuthenticationPropagationHeadersFactory.class, annotation.value());
+    }
+
+    @Test
+    public void testClientHeadersFactory_noneClientHeadersFactory() throws ClassNotFoundException {
+        Class currentWeatherDataV3Api = this.getClass().getClassLoader()
+                .loadClass("org.acme.openapi.weather.v3.api.CurrentWeatherDataV3Api");
+        assertTrue(currentWeatherDataV3Api.isAnnotationPresent(RegisterClientHeaders.class));
+        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV3Api
+                .getAnnotation(RegisterClientHeaders.class);
+        assertEquals(org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl.class, annotation.value());
+    }
+
+    @Test
+    public void testClientHeadersFactory_customClientHeadersFactory() throws ClassNotFoundException {
+        Class currentWeatherDataV4Api = this.getClass().getClassLoader()
+                .loadClass("org.acme.openapi.weather.v4.api.CurrentWeatherDataV4Api");
+        assertTrue(currentWeatherDataV4Api.isAnnotationPresent(RegisterClientHeaders.class));
+        RegisterClientHeaders annotation = (RegisterClientHeaders) currentWeatherDataV4Api
+                .getAnnotation(RegisterClientHeaders.class);
+        assertEquals(org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl.class, annotation.value());
     }
 
 }


### PR DESCRIPTION
New option to define ClientHeadersFactory class for @RegisterClientHeaders
Example: quarkus.openapi-generator.codegen.spec.my_openapi_yaml.client-header-factory=org.DummyClientHeadersFactory
Be default AuthenticationPropagationHeadersFactory class is used.
If 'client-header-factory' is set to 'none', @RegisterClientHeaders will be set without any ClientHeadersFactory and default DefaultClientHeadersFactoryImpl will be used.

Related issue: https://github.com/quarkiverse/quarkus-openapi-generator/issues/290
