### PR TITLE
#352 enable api key override for Authorization header (#355)

### DIFF
--- a/integration-tests/security/src/main/resources/application.properties
+++ b/integration-tests/security/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.openapi-generator.codegen.spec.open_weather_yaml.base-package=org.acme.o
 quarkus.openapi-generator.open_weather_yaml.auth.app_id.api-key=12345
 
 quarkus.openapi-generator.codegen.spec.fooopenapi_json.base-package=org.acme.openapi.foo
-quarkus.openapi-generator.fooopenapi_json.auth.JWT.api-key=fooapikey
+quarkus.openapi-generator.fooopenapi_json.auth.JWT.api-key=staticapikey
 
 # Authentication properties
 quarkus.openapi-generator.codegen.spec.open_weather_no_security_yaml.base-package=org.acme.openapi.weathernosec

--- a/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest.java
+++ b/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest.java
@@ -35,20 +35,35 @@ public class AuthorizationHeaderApiKeyCanFilterWithoutDuplicateAuthorizationTest
 
     @Test
     public void testNoMultipleAuthorizationHeadersAreSent() {
-        List<FooDTO> foos = fooResourceApi.getFoosUsingGET("not the fooapikey",
+        List<FooDTO> foos = fooResourceApi.getFoosUsingGET("dynamicapikey",
                 123465L);
         assertNotNull(foos);
 
         RequestPatternBuilder builder = getRequestedFor(
                 urlEqualTo("/api/foo/v2.0/foo?something=123465"))
-                .withHeader("Authorization", equalTo("fooapikey"));
+                .withHeader("Authorization", equalTo("dynamicapikey"));
         List<LoggedRequest> requestsWithAuthHeader = fooServer.findAll(builder);
-        assertEquals(1, requestsWithAuthHeader.size(), "more than one request");
+        assertEquals(1, requestsWithAuthHeader.size(), "unexpected Authorization header in request");
 
         LoggedRequest loggedRequest = requestsWithAuthHeader.get(0);
         HttpHeaders httpHeaders = loggedRequest.getHeaders();
         long authHeaderCount = httpHeaders.all().stream().filter(
                 httpHeader -> httpHeader.keyEquals("Authorization")).count();
         assertEquals(1, authHeaderCount, "multiple Authorization headers found");
+    }
+
+    @Test
+    public void testStaticApiKeyAsPrecedenceOverDynamicApiKey() {
+        List<FooDTO> foos = fooResourceApi.getFoosUsingGET("",
+                123465L);
+        assertNotNull(foos);
+
+        RequestPatternBuilder builder = getRequestedFor(
+                urlEqualTo("/api/foo/v2.0/foo?something=123465"))
+                .withHeader("Authorization", equalTo("staticapikey"));
+        List<LoggedRequest> requestsWithAuthHeader = fooServer.findAll(builder);
+        assertEquals(1, requestsWithAuthHeader.size(),
+                "did not use staticapikey from application.properties for Authorization header");
+
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/ApiKeyAuthenticationProvider.java
@@ -46,7 +46,11 @@ public class ApiKeyAuthenticationProvider extends AbstractAuthProvider {
                 requestContext.getCookies().put(apiKeyName, new Cookie(apiKeyName, getApiKey()));
                 break;
             case header:
-                requestContext.getHeaders().putSingle(apiKeyName, getApiKey());
+                if (requestContext.getHeaderString("Authorization") != null
+                        && !requestContext.getHeaderString("Authorization").isEmpty()) {
+                    requestContext.getHeaders().putSingle(apiKeyName, requestContext.getHeaderString("Authorization"));
+                } else
+                    requestContext.getHeaders().putSingle(apiKeyName, getApiKey());
                 break;
         }
     }


### PR DESCRIPTION
Co-authored-by: Laurent Perez <laurent.perez@itk.fr>
(cherry picked from commit 432a8a0f339f20d6e5d59746fabf75e844f9dba6)