### PR TITLE
Change api template to return jakarta Response instead of void

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ When using RESTEasy Reactive:
 
 ## Returning `Response` objects
 
-By default, this extension generates the methods according to their returning models based on the [OpenAPI specification Schema Object](https://spec.openapis.org/oas/v3.1.0#schema-object). If you want to return `jakarta.ws.rs.core.Response` instead, you can set the `return-response` property to `true`.
+By default, this extension generates the methods according to their returning models based on the [OpenAPI specification Schema Object](https://spec.openapis.org/oas/v3.1.0#schema-object). If no response model is defined, `jakarta.ws.rs.core.Response` is returned.
+
+If you want to return `jakarta.ws.rs.core.Response` in _all_ cases instead, you can set the `return-response` property to `true`.
 
 ### Example
 

--- a/deployment/src/main/resources/templates/api.qute
+++ b/deployment/src/main/resources/templates/api.qute
@@ -86,7 +86,7 @@ public interface {classname} {
         {#if return-response}
     public jakarta.ws.rs.core.Response {op.nickname}(
         {#else}
-    public {#if op.returnType}{op.returnType}{#else}void{/if} {op.nickname}(
+    public {#if op.returnType}{op.returnType}{#else}jakarta.ws.rs.core.Response{/if} {op.nickname}(
         {/if}
         {#if op.hasFormParams}
         {#if is-resteasy-reactive}


### PR DESCRIPTION
Imagine POSTing to a resource that creates something and returns no
payload but a 201 with a Location header. Right now, there is no way to
get that url. After this commit, it
will be possible