### PR TITLE
Fixed assertNotEquals with different types

### DIFF
--- a/integration-tests/circuit-breaker/src/test/java/io/quarkiverse/openapi/generator/it/circuit/breaker/SimpleOpenApiTest.java
+++ b/integration-tests/circuit-breaker/src/test/java/io/quarkiverse/openapi/generator/it/circuit/breaker/SimpleOpenApiTest.java
@@ -37,7 +37,7 @@ class SimpleOpenApiTest {
         compilationUnit.findAll(ClassOrInterfaceDeclaration.class).stream()
                 .map(c -> c.getAnnotationByClass(RegisterRestClient.class)).filter(Optional::isPresent).map(Optional::get)
                 .map(a -> a.asNormalAnnotationExpr().getPairs())
-                .forEach(n -> n.forEach(p -> assertNotEquals("baseUri", p.getName())));
+                .forEach(n -> n.forEach(p -> assertNotEquals("baseUri", p.getName().asString())));
 
         List<MethodDeclaration> methodDeclarations = compilationUnit.findAll(MethodDeclaration.class);
         assertThat(methodDeclarations).isNotEmpty();


### PR DESCRIPTION
The test was comparing equality between `String` and `SimpleName` objects.