### PR TITLE
Improved return-response tests

### DIFF
--- a/integration-tests/return-response/src/main/openapi/return-response-false-string-simple-openapi.yaml
+++ b/integration-tests/return-response/src/main/openapi/return-response-false-string-simple-openapi.yaml
@@ -1,0 +1,274 @@
+---
+openapi: 3.0.3
+info:
+  title: greeting-flow API
+  version: "1.0"
+paths:
+  /:
+    post:
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CloudEvent'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+  /hello:
+    get:
+      tags:
+        - ReturnResponseFalseString
+      operationId: hello
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+  /messaging/topics:
+    get:
+      tags:
+        - Quarkus Topics Information Resource
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    CloudEvent:
+      type: object
+      properties:
+        specVersion:
+          $ref: '#/components/schemas/SpecVersion'
+        id:
+          type: string
+        type:
+          type: string
+        source:
+          format: uri
+          type: string
+        dataContentType:
+          type: string
+        dataSchema:
+          format: uri
+          type: string
+        subject:
+          type: string
+        time:
+          format: date-time
+          type: string
+        attributeNames:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        extensionNames:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        data:
+          $ref: '#/components/schemas/CloudEventData'
+    CloudEventData:
+      type: object
+    EntityTag:
+      type: object
+      properties:
+        value:
+          type: string
+        weak:
+          type: boolean
+    Family:
+      enum:
+        - INFORMATIONAL
+        - SUCCESSFUL
+        - REDIRECTION
+        - CLIENT_ERROR
+        - SERVER_ERROR
+        - OTHER
+      type: string
+    Link:
+      type: object
+      properties:
+        uri:
+          format: uri
+          type: string
+        uriBuilder:
+          $ref: '#/components/schemas/UriBuilder'
+        rel:
+          type: string
+        rels:
+          type: array
+          items:
+            type: string
+        title:
+          type: string
+        type:
+          type: string
+        params:
+          type: object
+          additionalProperties:
+            type: string
+    Locale:
+      type: object
+      properties:
+        language:
+          type: string
+        script:
+          type: string
+        country:
+          type: string
+        variant:
+          type: string
+        extensionKeys:
+          uniqueItems: true
+          type: array
+          items:
+            format: byte
+            type: string
+        unicodeLocaleAttributes:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        unicodeLocaleKeys:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        iSO3Language:
+          type: string
+        iSO3Country:
+          type: string
+        displayLanguage:
+          type: string
+        displayScript:
+          type: string
+        displayCountry:
+          type: string
+        displayVariant:
+          type: string
+        displayName:
+          type: string
+    MediaType:
+      type: object
+      properties:
+        type:
+          type: string
+        subtype:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        wildcardType:
+          type: boolean
+        wildcardSubtype:
+          type: boolean
+    MultivaluedMapStringObject:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: object
+    MultivaluedMapStringString:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+    NewCookie:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        version:
+          format: int32
+          type: integer
+        path:
+          type: string
+        domain:
+          type: string
+        comment:
+          type: string
+        maxAge:
+          format: int32
+          type: integer
+        expiry:
+          format: date
+          type: string
+        secure:
+          type: boolean
+        httpOnly:
+          type: boolean
+    Response:
+      type: object
+      properties:
+        status:
+          format: int32
+          type: integer
+        statusInfo:
+          $ref: '#/components/schemas/StatusType'
+        entity:
+          type: object
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        language:
+          $ref: '#/components/schemas/Locale'
+        length:
+          format: int32
+          type: integer
+        allowedMethods:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        cookies:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NewCookie'
+        entityTag:
+          $ref: '#/components/schemas/EntityTag'
+        date:
+          format: date
+          type: string
+        lastModified:
+          format: date
+          type: string
+        location:
+          format: uri
+          type: string
+        links:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        metadata:
+          $ref: '#/components/schemas/MultivaluedMapStringObject'
+        headers:
+          $ref: '#/components/schemas/MultivaluedMapStringObject'
+        stringHeaders:
+          $ref: '#/components/schemas/MultivaluedMapStringString'
+    SpecVersion:
+      enum:
+        - V03
+        - V1
+      type: string
+    StatusType:
+      type: object
+      properties:
+        statusCode:
+          format: int32
+          type: integer
+        family:
+          $ref: '#/components/schemas/Family'
+        reasonPhrase:
+          type: string
+    UriBuilder:
+      type: object

--- a/integration-tests/return-response/src/main/openapi/return-response-false-void-simple-openapi.yaml
+++ b/integration-tests/return-response/src/main/openapi/return-response-false-void-simple-openapi.yaml
@@ -21,15 +21,11 @@ paths:
   /hello:
     get:
       tags:
-        - Response
+        - ReturnResponseFalseVoid
       operationId: hello
       responses:
         "200":
           description: OK
-          content:
-            text/plain:
-              schema:
-                type: string
   /messaging/topics:
     get:
       tags:

--- a/integration-tests/return-response/src/main/openapi/return-response-true-string-simple-openapi.yaml
+++ b/integration-tests/return-response/src/main/openapi/return-response-true-string-simple-openapi.yaml
@@ -1,0 +1,274 @@
+---
+openapi: 3.0.3
+info:
+  title: greeting-flow API
+  version: "1.0"
+paths:
+  /:
+    post:
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CloudEvent'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+  /hello:
+    get:
+      tags:
+        - ReturnResponseTrueString
+      operationId: hello
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+  /messaging/topics:
+    get:
+      tags:
+        - Quarkus Topics Information Resource
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    CloudEvent:
+      type: object
+      properties:
+        specVersion:
+          $ref: '#/components/schemas/SpecVersion'
+        id:
+          type: string
+        type:
+          type: string
+        source:
+          format: uri
+          type: string
+        dataContentType:
+          type: string
+        dataSchema:
+          format: uri
+          type: string
+        subject:
+          type: string
+        time:
+          format: date-time
+          type: string
+        attributeNames:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        extensionNames:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        data:
+          $ref: '#/components/schemas/CloudEventData'
+    CloudEventData:
+      type: object
+    EntityTag:
+      type: object
+      properties:
+        value:
+          type: string
+        weak:
+          type: boolean
+    Family:
+      enum:
+        - INFORMATIONAL
+        - SUCCESSFUL
+        - REDIRECTION
+        - CLIENT_ERROR
+        - SERVER_ERROR
+        - OTHER
+      type: string
+    Link:
+      type: object
+      properties:
+        uri:
+          format: uri
+          type: string
+        uriBuilder:
+          $ref: '#/components/schemas/UriBuilder'
+        rel:
+          type: string
+        rels:
+          type: array
+          items:
+            type: string
+        title:
+          type: string
+        type:
+          type: string
+        params:
+          type: object
+          additionalProperties:
+            type: string
+    Locale:
+      type: object
+      properties:
+        language:
+          type: string
+        script:
+          type: string
+        country:
+          type: string
+        variant:
+          type: string
+        extensionKeys:
+          uniqueItems: true
+          type: array
+          items:
+            format: byte
+            type: string
+        unicodeLocaleAttributes:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        unicodeLocaleKeys:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        iSO3Language:
+          type: string
+        iSO3Country:
+          type: string
+        displayLanguage:
+          type: string
+        displayScript:
+          type: string
+        displayCountry:
+          type: string
+        displayVariant:
+          type: string
+        displayName:
+          type: string
+    MediaType:
+      type: object
+      properties:
+        type:
+          type: string
+        subtype:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        wildcardType:
+          type: boolean
+        wildcardSubtype:
+          type: boolean
+    MultivaluedMapStringObject:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: object
+    MultivaluedMapStringString:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+    NewCookie:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        version:
+          format: int32
+          type: integer
+        path:
+          type: string
+        domain:
+          type: string
+        comment:
+          type: string
+        maxAge:
+          format: int32
+          type: integer
+        expiry:
+          format: date
+          type: string
+        secure:
+          type: boolean
+        httpOnly:
+          type: boolean
+    Response:
+      type: object
+      properties:
+        status:
+          format: int32
+          type: integer
+        statusInfo:
+          $ref: '#/components/schemas/StatusType'
+        entity:
+          type: object
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        language:
+          $ref: '#/components/schemas/Locale'
+        length:
+          format: int32
+          type: integer
+        allowedMethods:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        cookies:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NewCookie'
+        entityTag:
+          $ref: '#/components/schemas/EntityTag'
+        date:
+          format: date
+          type: string
+        lastModified:
+          format: date
+          type: string
+        location:
+          format: uri
+          type: string
+        links:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        metadata:
+          $ref: '#/components/schemas/MultivaluedMapStringObject'
+        headers:
+          $ref: '#/components/schemas/MultivaluedMapStringObject'
+        stringHeaders:
+          $ref: '#/components/schemas/MultivaluedMapStringString'
+    SpecVersion:
+      enum:
+        - V03
+        - V1
+      type: string
+    StatusType:
+      type: object
+      properties:
+        statusCode:
+          format: int32
+          type: integer
+        family:
+          $ref: '#/components/schemas/Family'
+        reasonPhrase:
+          type: string
+    UriBuilder:
+      type: object

--- a/integration-tests/return-response/src/main/openapi/return-response-true-void-simple-openapi.yaml
+++ b/integration-tests/return-response/src/main/openapi/return-response-true-void-simple-openapi.yaml
@@ -21,15 +21,11 @@ paths:
   /hello:
     get:
       tags:
-        - Model
+        - ReturnResponseTrueVoid
       operationId: hello
       responses:
         "200":
           description: OK
-          content:
-            text/plain:
-              schema:
-                type: string
   /messaging/topics:
     get:
       tags:

--- a/integration-tests/return-response/src/main/resources/application.properties
+++ b/integration-tests/return-response/src/main/resources/application.properties
@@ -1,4 +1,9 @@
-quarkus.openapi-generator.codegen.spec.model_simple_openapi_yaml.base-package=org.acme.openapi
+quarkus.openapi-generator.codegen.spec.return_response_false_string_simple_openapi_yaml.base-package = org.acme.openapi
+quarkus.openapi-generator.codegen.spec.return_response_false_void_simple_openapi_yaml.base-package = org.acme.openapi
+quarkus.openapi-generator.codegen.spec.return_response_true_string_simple_openapi_yaml.base-package = org.acme.openapi
+quarkus.openapi-generator.codegen.spec.return_response_true_void_simple_openapi_yaml.base-package = org.acme.openapi
 
-quarkus.openapi-generator.codegen.spec.response_simple_openapi_yaml.base-package=org.acme.openapi
-quarkus.openapi-generator.codegen.spec.response_simple_openapi_yaml.return-response=true
+quarkus.openapi-generator.codegen.spec.return_response_false_string_simple_openapi_yaml.return-response = false
+quarkus.openapi-generator.codegen.spec.return_response_false_void_simple_openapi_yaml.return-response = false
+quarkus.openapi-generator.codegen.spec.return_response_true_string_simple_openapi_yaml.return-response = true
+quarkus.openapi-generator.codegen.spec.return_response_true_void_simple_openapi_yaml.return-response = true

--- a/integration-tests/return-response/src/test/java/io/quarkiverse/openapi/generator/it/ReturnResponseTest.java
+++ b/integration-tests/return-response/src/test/java/io/quarkiverse/openapi/generator/it/ReturnResponseTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.ws.rs.core.Response;
 
-import org.acme.openapi.api.ModelApi;
-import org.acme.openapi.api.ResponseApi;
+import org.acme.openapi.api.ReturnResponseFalseStringApi;
+import org.acme.openapi.api.ReturnResponseFalseVoidApi;
+import org.acme.openapi.api.ReturnResponseTrueStringApi;
+import org.acme.openapi.api.ReturnResponseTrueVoidApi;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -14,14 +16,26 @@ import io.quarkus.test.junit.QuarkusTest;
 class ReturnResponseTest {
 
     @Test
-    void testModel() throws NoSuchMethodException {
-        assertThat(ModelApi.class.getMethod("hello").getReturnType())
+    void testReturnResponseFalseString() throws NoSuchMethodException {
+        assertThat(ReturnResponseFalseStringApi.class.getMethod("hello").getReturnType())
                 .isEqualTo(String.class);
     }
 
     @Test
-    void testResponse() throws NoSuchMethodException {
-        assertThat(ResponseApi.class.getMethod("hello").getReturnType())
+    void testReturnResponseTrueString() throws NoSuchMethodException {
+        assertThat(ReturnResponseTrueStringApi.class.getMethod("hello").getReturnType())
+                .isEqualTo(Response.class);
+    }
+
+    @Test
+    void testReturnResponseFalseVoid() throws NoSuchMethodException {
+        assertThat(ReturnResponseFalseVoidApi.class.getMethod("hello").getReturnType())
+                .isEqualTo(Void.TYPE);
+    }
+
+    @Test
+    void testReturnResponseTrueVoid() throws NoSuchMethodException {
+        assertThat(ReturnResponseTrueVoidApi.class.getMethod("hello").getReturnType())
                 .isEqualTo(Response.class);
     }
 }


### PR DESCRIPTION
This PR adds more tests to validate if methods return `Response` instead of `void` when configured.

This is related to: https://github.com/quarkiverse/quarkus-openapi-generator/issues/424