### PR TITLE
docs: fix documentation (#470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,6 @@ By default, the `@RegisterRestClient` `configKey` property is the sanitized name
 /* omitted */
 @RegisterRestClient(configKey="petstore_json")
 public interface DefaultApi { /* omitted */ }
-}
 ```
 
 If you want to use a different configKey than the default one, you can set the `quarkus.openapi-generator.codegen.spec.petstore_json.[config-key]` property.


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-openapi-generator/pull/470