### PR TITLE
Determine REST_CLIENT_REACTIVE_JACKSON capability properly

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>swagger-parser</artifactId>
       <version>${version.io.swagger.parser}</version>
     </dependency>
+    <dependency>
+      <!-- Use Quarkus compatible version -->
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
 
     <!-- OpenApi Generator -->
     <dependency>

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.eclipse.microprofile.config.Config;
 import org.openapitools.codegen.config.GlobalSettings;
 
@@ -33,6 +34,7 @@ import io.quarkiverse.openapi.generator.deployment.wrapper.OpenApiClassicClientG
 import io.quarkiverse.openapi.generator.deployment.wrapper.OpenApiClientGeneratorWrapper;
 import io.quarkiverse.openapi.generator.deployment.wrapper.OpenApiReactiveClientGeneratorWrapper;
 import io.quarkus.bootstrap.prebuild.CodeGenException;
+import io.quarkus.builder.Version;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.CodeGenContext;
 import io.quarkus.deployment.CodeGenProvider;
@@ -52,6 +54,10 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
 
     private static final String DEFAULT_PACKAGE = "org.openapi.quarkus";
     private static final String CONFIG_KEY_PROPERTY = "config-key";
+
+    private static final DefaultArtifactVersion BREAKING_QUARKUS_VERSION = new DefaultArtifactVersion("3.4.1");
+    private static final DefaultArtifactVersion TARGET_QUARKUS_VERSION = new DefaultArtifactVersion(Version.getVersion());
+    private static final String REST_CLIENT_REACTIVE_JACKSON_BEFORE_QUARKUS_3_4_1 = "io.quarkus.rest.client.reactive.jackson";
 
     /**
      * The input base directory from
@@ -132,7 +138,7 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
     }
 
     private static boolean isJacksonReactiveClientPresent(CodeGenContext context) {
-        return isExtensionCapabilityPresent(context, Capability.REST_CLIENT_REACTIVE_JACKSON);
+        return isExtensionCapabilityPresent(context, determineRestClienReactiveJacksonCapabilityId());
     }
 
     private static boolean isJacksonClassicClientPresent(CodeGenContext context) {
@@ -149,6 +155,14 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
         return context.applicationModel().getExtensionCapabilities().stream()
                 .flatMap(extensionCapability -> extensionCapability.getProvidesCapabilities().stream())
                 .anyMatch(capability::equals);
+    }
+
+    private static String determineRestClienReactiveJacksonCapabilityId() {
+        if (TARGET_QUARKUS_VERSION.compareTo(BREAKING_QUARKUS_VERSION) < 0) {
+            // in case the target Quarkus version is older than 3.4.1 we need to return the old Capability id for REST_CLIENT_REACTIVE_JACKSON
+            return REST_CLIENT_REACTIVE_JACKSON_BEFORE_QUARKUS_3_4_1;
+        }
+        return Capability.REST_CLIENT_REACTIVE_JACKSON;
     }
 
     // TODO: do not generate if the output dir has generated files and the openapi file has the same checksum of the previous run

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -157,7 +157,7 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
                 .anyMatch(capability::equals);
     }
 
-    private static String determineRestClienReactiveJacksonCapabilityId() {
+    private static String determineRestClientReactiveJacksonCapabilityId() {
         if (TARGET_QUARKUS_VERSION.compareTo(BREAKING_QUARKUS_VERSION) < 0) {
             // in case the target Quarkus version is older than 3.4.1 we need to return the old Capability id for REST_CLIENT_REACTIVE_JACKSON
             return REST_CLIENT_REACTIVE_JACKSON_BEFORE_QUARKUS_3_4_1;

--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -138,7 +138,7 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
     }
 
     private static boolean isJacksonReactiveClientPresent(CodeGenContext context) {
-        return isExtensionCapabilityPresent(context, determineRestClienReactiveJacksonCapabilityId());
+        return isExtensionCapabilityPresent(context, determineRestClientReactiveJacksonCapabilityId());
     }
 
     private static boolean isJacksonClassicClientPresent(CodeGenContext context) {


### PR DESCRIPTION
This PR fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/499

Some thoughts on this PR:
- I'm wasn't able to write some automated tests. That's because the test setup would be quite complex. We would need to compile the extension with Quarkus ``4.3.1`` and would test the extension with a business app using Quarkus in a previous 3.X version. Anyhow, I was able to test the functionality manually. Up to you if this would be good enough to continue. Otherwise somebody else is most welcome to write such a test.
- This code can be reverted as soon as we drop support for Quarkus versions earlier than ``3.4.1`` 
- I did some further testing and it looks like ``quarkus-openapi-generator`` in version ``2.2.10`` does also not support the Quarkus LTS branch (e.g. ``3.2.5.Final``). At least in my test scenario, I got also a ``rest.client.reactive.jackson`` related issue. This is different from the issue https://github.com/quarkiverse/quarkus-openapi-generator/issues/499 but maybe someone else can verify that. So we can cover it in another issue.