### PR TITLE
Fixes wrong behavior with right enum name

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -168,7 +168,7 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
         // remove _ at start and end
         enumVarName = enumVarName.replaceAll("^_+|_+$", "");
-        enumVarName = enumVarName.replaceFirst("\\d.*", "_".concat(enumVarName));
+        enumVarName = enumVarName.replaceFirst("^(\\d).*", "_".concat(enumVarName));
 
         return enumVarName.toUpperCase(Locale.ROOT);
     }

--- a/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegenTest.java
+++ b/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegenTest.java
@@ -16,7 +16,10 @@ class QuarkusJavaClientCodegenTest {
             "123456,String,_123456",
             "quarkus_resources,String,QUARKUS_RESOURCES",
             "123456,Integer,NUMBER_123456", // old behavior
-            "123+123,Long,NUMBER_123PLUS_123" // old behavior
+            "123+123,Long,NUMBER_123PLUS_123", // old behavior,
+            "M123,String,M123",
+            "MA456,String,MA456",
+            "P1,String,P1",
     })
     void toEnumVarName(String value, String dataType, String expectedVarName) {
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/537
Fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/421

I'm sorry for the issue.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
