### PR TITLE
[issue: #536] - Added annotation @Path("/") when operation is empty

### DIFF
--- a/deployment/src/main/resources/templates/libraries/microprofile/api.qute
+++ b/deployment/src/main/resources/templates/libraries/microprofile/api.qute
@@ -58,6 +58,8 @@ public interface {classname} {
     @{op.httpMethod}
     {#if op.subresourceOperation}
     @Path("{op.path}")
+    {#else}
+    @Path("/")
     {/if}
     {#if op.hasConsumes}
     @Consumes(\{{#for consume in op.consumes}"{consume.mediaType}"{#if consume_hasNext}, {/if}{/for}\})


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Include @Path("/")  when the operation is empty

- According to the issue in some applications the client method without annotation @Path("/") causes 404 NOT_FOUND.

Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/536
