### PR TITLE
Do not add blank Bearer token

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BearerAuthenticationProvider.java
@@ -34,8 +34,10 @@ public class BearerAuthenticationProvider extends AbstractAuthProvider {
         } else {
             bearerToken = getBearerToken();
         }
-        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION,
-                AuthUtils.authTokenOrBearer(this.scheme, bearerToken));
+        if (!bearerToken.isBlank()) {
+            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION,
+                    AuthUtils.authTokenOrBearer(this.scheme, bearerToken));
+        }
     }
 
     private String getBearerToken() {


### PR DESCRIPTION
Request for `BearerAuthenticationProvider` not to add a blank token to the `Authorization` header, as doing so will never satisfy any real authorization requirement, and may cause a request failure when multiple `Authorization` headers are sent due to multiple (optional) `security` schemes are defined on an endpoint.

This change could be extended to the other `AuthProvider`s, but I have not been using those.

Fixes: #589