### PR TITLE
Dropped support for Quarkus 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Maven automatically formats code and organizes imports when you run `mvn verify`
 
 ## Quarkus 3 and Quarkus 2 support
 
-This extension supports versions 3 and 2 of Quarkus and the code base is different for each Quarkus version. Therefore, we have the `main` branch supporting Quarkus 3, and the `quarkus2` branch supporting Quarkus 2. Preferably send your PRs to the `main` branch and [we will backport them to the `quarkus2` branch](#backporting-between-branches).
+We no longer offer support for Quarkus 2. This extension used to support versions 3 and 2 of Quarkus and the code base was different for each Quarkus version. Therefore, we have the `main` branch supporting Quarkus 3, and the `quarkus2` archived branch supporting Quarkus 2. Note that no updates are planned for Quarkus 2 and features and bug fixes are not backported to the `quarkus2` branch.
 
 ## For the maintainers
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > **⚠️** This is the instructions for the latest SNAPSHOT version (main branch). Please, see the [latest **released** documentation](https://github.com/quarkiverse/quarkus-openapi-generator/blob/1.0.1/README.md) if you are looking for instructions.
 
-> **⚠️** Version 2.x.x of this extension (`main` branch) supports Quarkus 3, and version 1.x.x (`quarkus2` branch) supports Quarkus 2.
+> **⚠️** Check versions 1.x.x if you're still using Quarkus 2. But be aware that we no longer support Quarkus 2. That means there are no updates planned for those versions.
 
 Quarkus' extension for generation of [Rest Clients](https://quarkus.io/guides/rest-client) based on OpenAPI specification files.
 

--- a/docs/modules/ROOT/pages/includes/getting-started.adoc
+++ b/docs/modules/ROOT/pages/includes/getting-started.adoc
@@ -1,7 +1,7 @@
 
 Add the following dependency to your project's `pom.xml` file:
 
-WARNING: Version 2.x.x of this extension supports Quarkus 3, and version 1.x.x supports Quarkus 2.
+WARNING: Version 2.x.x of this extension supports Quarkus 3, and version 1.x.x supports Quarkus 2. We strongly recommend you to use version 2.x.x. No updates are planned for version 1.x.x.
 
 [source,xml]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,7 +4,7 @@
 
 WARNING: This is the instructions for the latest SNAPSHOT version (main branch). Please, see the https://github.com/quarkiverse/quarkus-openapi-generator/blob/1.0.1/README.md[latest **released** documentation] if you are looking for instructions.
 
-WARNING: Version 2.x.x of this extension (`main` branch) supports Quarkus 3, and version 1.x.x (`quarkus2` branch) supports Quarkus 2.
+WARNING: Check versions 1.x.x if you're still using Quarkus 2. But be aware that we no longer support Quarkus 2. That means there are no updates planned for those versions.
 
 Quarkus' extension for generation of https://quarkus.io/guides/rest-client[Rest Clients] based on OpenAPI specification files.
 


### PR DESCRIPTION
This PR updates the docs to drop support for Quarkus2.

@ricardozanini can you please archive `quarkus2` branch? I don't have permission.