### PR TITLE
[issue: #651] Adding initialization for non requiered containers in add/put method

### DIFF
--- a/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
+++ b/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
@@ -107,12 +107,18 @@ public class {m.classname} {#if m.parent}extends {m.parent}{/if}{#if m.serializa
     }
     {#if v.isArray}
     public {m.classname} add{v.nameInCamelCase}Item({v.items.datatypeWithEnum} {v.name}Item) {
+        if (this.{v.name} == null){
+            {v.name} = {#if v.defaultValue}{v.defaultValue}{#else}new {#if v.uniqueItems}LinkedHashSet{/if}{#if !v.uniqueItems}ArrayList{/if}<>(){/if};
+        }
         this.{v.name}.add({v.name}Item);
         return this;
     }
     {/if}
     {#if v.isMap}
     public {m.classname} put{v.nameInCamelCase}Item(String key, {v.items.datatypeWithEnum} {v.name}Item) {
+           if (this.{v.name} == null){
+                {v.name} = {#if v.defaultValue}{v.defaultValue}{#else}new HashMap<>(){/if};
+            }
         this.{v.name}.put(key, {v.name}Item);
         return this;
     }

--- a/integration-tests/array-enum/src/main/openapi/array-enum.yaml
+++ b/integration-tests/array-enum/src/main/openapi/array-enum.yaml
@@ -30,6 +30,7 @@ paths:
 components:
   schemas:
     webhook_create_update_payload:
+      required: [url, subscriptions]
       type: object
       properties:
         url:
@@ -47,3 +48,12 @@ components:
               - message_updated
               - webwidget_triggered
           description: The events you want to subscribe to.
+        message:
+          type: array
+          items:
+            type: string
+          description: Non required Field to safe messages
+        messageMap:
+          type: object
+          additionalProperties: true
+          description: Non required Map Field to safe messages

--- a/integration-tests/array-enum/src/test/java/io/quarkiverse/openapi/generator/it/ArrayEnumTest.java
+++ b/integration-tests/array-enum/src/test/java/io/quarkiverse/openapi/generator/it/ArrayEnumTest.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.openapi.quarkus.array_enum_yaml.api.ArrayEnumResourceApi;
+import org.openapi.quarkus.array_enum_yaml.model.WebhookCreateUpdatePayload;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -20,5 +21,19 @@ class ArrayEnumTest {
     @Test
     void apiIsBeingGenerated() {
         assertThat(api).isNotNull();
+    }
+
+    @Test
+    void modelNonRequieredFieldTest() {
+        WebhookCreateUpdatePayload webhookCreateUpdatePayload = new WebhookCreateUpdatePayload();
+
+        assertThat(webhookCreateUpdatePayload.getMessage()).isNull();
+        assertThat(webhookCreateUpdatePayload.getMessageMap()).isNull();
+
+        webhookCreateUpdatePayload.addMessageItem("Test");
+        webhookCreateUpdatePayload.putMessageMapItem("Test", "Test");
+
+        assertThat(webhookCreateUpdatePayload.getMessage()).isNotNull();
+        assertThat(webhookCreateUpdatePayload.getMessageMap()).isNotNull();
     }
 }

--- a/integration-tests/array-enum/src/test/java/io/quarkiverse/openapi/generator/it/ArrayEnumTest.java
+++ b/integration-tests/array-enum/src/test/java/io/quarkiverse/openapi/generator/it/ArrayEnumTest.java
@@ -24,7 +24,7 @@ class ArrayEnumTest {
     }
 
     @Test
-    void modelNonRequieredFieldTest() {
+    void modelNonRequiredFieldTest() {
         WebhookCreateUpdatePayload webhookCreateUpdatePayload = new WebhookCreateUpdatePayload();
 
         assertThat(webhookCreateUpdatePayload.getMessage()).isNull();


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

When in the model there is a field, that is for example a list and is not diffined as requierd in the yaml, then in the add method there is no initialization, if this field is null.

Fix it as openapi does it, in each "add" method for a container, generate a check if the container is null, if it's null instantiate a new empty container. 

@ricardozanini 
Is there an option to backport this to 2.2.16? Or should we do this local in our Nexus?