### PR TITLE
POC: error when input/openapi has cookies

### DIFF
--- a/deployment/src/test/resources/openapi/petstore-openapi.json
+++ b/deployment/src/test/resources/openapi/petstore-openapi.json
@@ -191,6 +191,14 @@
                 "sold"
               ]
             }
+          },
+          {
+            "name": "example-cookie",
+            "in": "cookie",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
Expected Result:
``` java
  @GET
    @Path("/findByStatus")
    @Produces({"application/xml", "application/json"})
    @GeneratedMethod ("findPetsByStatus")
    public List<Pet> findPetsByStatus(
        @CookieParam("example-cookie") String exampleCookie, 
        @GeneratedParam("status") @QueryParam("status") String status
    ); ```

Actual output:

``` java
    @GET
    @Path("/findByStatus")
    @Produces({"application/xml", "application/json"})
    @GeneratedMethod ("findPetsByStatus")
    public List<Pet> findPetsByStatus(
        , 
        @GeneratedParam("status") @QueryParam("status") String status
    );
```

Cannot address the origin of this error. Any thoughts? 