### PR TITLE
Add support for large YAML input

### DIFF
--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/ApicurioOpenApiServerCodegen.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/ApicurioOpenApiServerCodegen.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -94,7 +95,12 @@ public class ApicurioOpenApiServerCodegen implements CodeGenProvider {
 
     private File convertToJSON(Path yamlPath) throws CodeGenException {
         try {
-            ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+            LoaderOptions loaderOptions = new LoaderOptions();
+            loaderOptions.setCodePointLimit(12 * 1024 * 1024); // 12 MB
+            YAMLFactory yamlFactory = YAMLFactory.builder()
+                    .loaderOptions(loaderOptions)
+                    .build();
+            ObjectMapper yamlReader = new ObjectMapper(yamlFactory);
             Object obj = yamlReader.readValue(yamlPath.toFile(), Object.class);
             ObjectMapper jsonWriter = new ObjectMapper();
             File jsonFile = File.createTempFile(yamlPath.toFile().getName(), ".json");

--- a/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/CodegenTest.java
+++ b/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/CodegenTest.java
@@ -50,6 +50,17 @@ public class CodegenTest {
     }
 
     @Test
+    public void testYamlHuge() throws CodeGenException {
+        Config config = MockConfigUtils.getTestConfig("yaml-huge.application.properties");
+        CodeGenContext codeGenContext = new CodeGenContext(null, Path.of(OUT_DIR, "yaml"), WORK_DIR,
+                INPUT_DIR, false, config, true);
+        ApicurioOpenApiServerCodegen apicurioOpenApiServerCodegen = new ApicurioOpenApiServerCodegen();
+        apicurioOpenApiServerCodegen.trigger(codeGenContext);
+        assertTrue(
+                Files.exists(Path.of("target/generated-test-sources/yaml/io/petstore/PetResource.java")));
+    }
+
+    @Test
     public void testInputDir() throws CodeGenException {
         Config config = MockConfigUtils.getTestConfig("inputDir.application.properties");
         CodeGenContext codeGenContext = new CodeGenContext(null, Path.of(OUT_DIR, "inputDir"), WORK_DIR,

--- a/server/deployment/src/test/resources/io/quarkiverse/openapi/server/generator/deployment/yaml-huge.application.properties
+++ b/server/deployment/src/test/resources/io/quarkiverse/openapi/server/generator/deployment/yaml-huge.application.properties
@@ -1,0 +1,2 @@
+quarkus.openapi.generator.spec=petstore-openapi-huge.yaml
+quarkus.openapi.generator.base-package=io.petstore


### PR DESCRIPTION
This PR relates to [this issue](https://github.com/quarkiverse/quarkus-openapi-generator/issues/786). 
This PR proposes a change to the openAPI-generator code to allow accepting large YAML input files, (12MB). This will help using larger open-api documents (e.g, the github-openapi spec) on projects that require the generator. 

