### PR TITLE
Adding NotNull annotation for required fields

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
@@ -39,7 +39,7 @@ public class {m.classname} {#if m.parent}extends {m.parent}{/if}{#if m.serializa
       * {v.description}
      **/
     {/if}
-    {#if v.hasValidation}{#include beanValidation.qute p=v/}{/if}
+    {#if v.hasValidation || v.required}{#include beanValidation.qute p=v/}{/if}
     {#if v.isContainer}
     private {v.datatypeWithEnum} {v.name}{#if v.required && v.defaultValue} = {v.defaultValue}{/if};
     {#else}

--- a/client/integration-tests/bean-validation/src/main/openapi/bean-validation-true.yaml
+++ b/client/integration-tests/bean-validation/src/main/openapi/bean-validation-true.yaml
@@ -47,6 +47,7 @@ components:
       required:
         - id
         - name
+        - secondName
         - size
       properties:
         id:
@@ -58,6 +59,8 @@ components:
           pattern: "[a-zA-Z]*"
           minLength: 1
           maxLength: 10
+        secondName:
+          type: string
         size:
           type: number
           minimum: 1.0

--- a/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
+++ b/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
@@ -43,9 +44,10 @@ class BeanValidationTest {
     void testValidationAnnotationsAreInPlaceModel() throws Exception {
         Field id = ValidatedObject.class.getDeclaredField("id");
         Field name = ValidatedObject.class.getDeclaredField("name");
+        Field secondName = ValidatedObject.class.getDeclaredField("secondName");
         Field size = ValidatedObject.class.getDeclaredField("size");
 
-        assertThat(Arrays.stream(ValidatedObject.class.getFields())
+        assertThat(Stream.of(id, name, secondName, size)
                 .allMatch(f -> f.isAnnotationPresent(NotNull.class)))
                 .isTrue();
 

--- a/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
+++ b/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
@@ -88,7 +88,7 @@ class BeanValidationTest {
         Field name = UnvalidatedObject.class.getDeclaredField("name");
         Field size = UnvalidatedObject.class.getDeclaredField("size");
 
-        assertThat(Arrays.stream(UnvalidatedObject.class.getFields())
+        assertThat(Stream.of(id, name, size)
                 .noneMatch(f -> f.isAnnotationPresent(NotNull.class))).isTrue();
         assertThat(id.isAnnotationPresent(Min.class)).isFalse();
         assertThat(id.isAnnotationPresent(Max.class)).isFalse();


### PR DESCRIPTION
Following changes concern generating POJOs using client with `use-bean-validation` property set to `true`.

There is a functionality of annotating required fields with Jakarta @NotNull. According to my tests, it does not work in case when the field has no other constraints (like minLength, maxLength, etc.). I expect that required fields are annotated with NotNull no matter it has any other constraints or not.

I would suggest a little modification in pojo.qute in order to annotate every required field.
