### PR TITLE
No Issue - Add a warn in the logs when elements have duplicated vars

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -134,6 +134,7 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     }
 
+    @Override
     public CodegenModel fromModel(String name, Schema model) {
         CodegenModel codegenModel = super.fromModel(name, model);
         warnIfDuplicated(codegenModel);

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -2,7 +2,14 @@ package io.quarkiverse.openapi.generator.deployment.wrapper;
 
 import java.io.File;
 import java.net.URL;
-import java.util.*;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;

--- a/client/deployment/src/test/resources/openapi/issue-flink.yaml
+++ b/client/deployment/src/test/resources/openapi/issue-flink.yaml
@@ -1,0 +1,3452 @@
+openapi: 3.0.1
+info:
+  title: Flink JobManager REST API
+  contact:
+    email: user@flink.apache.org
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: v1/1.20-SNAPSHOT
+paths:
+  /cluster:
+    delete:
+      description: Shuts down the cluster
+      operationId: shutdownCluster
+      responses:
+        "200":
+          description: The request was successful.
+  /config:
+    get:
+      description: Returns the configuration of the WebUI.
+      operationId: getDashboardConfiguration
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardConfiguration'
+  /datasets:
+    get:
+      description: Returns all cluster data sets.
+      operationId: getClusterDataSetList
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterDataSetListResponseBody'
+  /datasets/delete/{triggerid}:
+    get:
+      description: Returns the status for the delete operation of a cluster data set.
+      operationId: getClusterDataSetDeleteStatus
+      parameters:
+        - name: triggerid
+          in: path
+          description: 32-character hexadecimal string that identifies an asynchronous
+            operation trigger ID. The ID was returned then the operation was triggered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TriggerId'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsynchronousOperationResult'
+  /datasets/{datasetid}:
+    delete:
+      description: Triggers the deletion of a cluster data set. This async operation
+        would return a 'triggerid' for further query identifier.
+      operationId: deleteClusterDataSet
+      parameters:
+        - name: datasetid
+          in: path
+          description: 32-character hexadecimal string value that identifies a cluster
+            data set.
+          required: true
+          schema:
+            $ref: '#/components/schemas/IntermediateDataSetID'
+      responses:
+        "202":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /jars:
+    get:
+      description: Returns a list of all jars previously uploaded via '/jars/upload'.
+      operationId: getJarList
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JarListInfo'
+  /jars/upload:
+    post:
+      description: |-
+        Uploads a jar to the cluster. The jar must be sent as multi-part data. Make sure that the "Content-Type" header is set to "application/x-java-archive", as some http libraries do not add the header by default.
+        Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@path/to/flink-job.jar" http://hostname:port/jars/upload'.
+      operationId: uploadJar
+      requestBody:
+        content:
+          application/x-java-archive:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JarUploadResponseBody'
+  /jars/{jarid}:
+    delete:
+      description: Deletes a jar previously uploaded via '/jars/upload'.
+      operationId: deleteJar
+      parameters:
+        - name: jarid
+          in: path
+          description: "String value that identifies a jar. When uploading the jar a\
+          \ path is returned, where the filename is the ID. This value is equivalent\
+          \ to the `id` field in the list of uploaded jars (/jars)."
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+  /jars/{jarid}/plan:
+    post:
+      description: Returns the dataflow plan of a job contained in a jar previously
+        uploaded via '/jars/upload'. Program arguments can be passed both via the
+        JSON request (recommended) or query parameters.
+      operationId: generatePlanFromJar
+      parameters:
+        - name: jarid
+          in: path
+          description: "String value that identifies a jar. When uploading the jar a\
+          \ path is returned, where the filename is the ID. This value is equivalent\
+          \ to the `id` field in the list of uploaded jars (/jars)."
+          required: true
+          schema:
+            type: string
+        - name: program-args
+          in: query
+          description: "Deprecated, please use 'programArg' instead. String value that\
+          \ specifies the arguments for the program or plan"
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: programArg
+          in: query
+          description: Comma-separated list of program arguments.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: entry-class
+          in: query
+          description: String value that specifies the fully qualified name of the entry
+            point class. Overrides the class defined in the jar file manifest.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: parallelism
+          in: query
+          description: Positive integer value that specifies the desired parallelism
+            for the job.
+          required: false
+          style: form
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JarPlanRequestBody'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobPlanInfo'
+  /jars/{jarid}/run:
+    post:
+      description: Submits a job by running a jar previously uploaded via '/jars/upload'.
+        Program arguments can be passed both via the JSON request (recommended) or
+        query parameters.
+      operationId: submitJobFromJar
+      parameters:
+        - name: jarid
+          in: path
+          description: "String value that identifies a jar. When uploading the jar a\
+          \ path is returned, where the filename is the ID. This value is equivalent\
+          \ to the `id` field in the list of uploaded jars (/jars)."
+          required: true
+          schema:
+            type: string
+        - name: allowNonRestoredState
+          in: query
+          description: Boolean value that specifies whether the job submission should
+            be rejected if the savepoint contains state that cannot be mapped back to
+            the job.
+          required: false
+          style: form
+          schema:
+            type: boolean
+        - name: savepointPath
+          in: query
+          description: String value that specifies the path of the savepoint to restore
+            the job from.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: program-args
+          in: query
+          description: "Deprecated, please use 'programArg' instead. String value that\
+          \ specifies the arguments for the program or plan"
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: programArg
+          in: query
+          description: Comma-separated list of program arguments.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: entry-class
+          in: query
+          description: String value that specifies the fully qualified name of the entry
+            point class. Overrides the class defined in the jar file manifest.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: parallelism
+          in: query
+          description: Positive integer value that specifies the desired parallelism
+            for the job.
+          required: false
+          style: form
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JarRunRequestBody'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JarRunResponseBody'
+  /jobmanager/config:
+    get:
+      description: Returns the cluster configuration.
+      operationId: getClusterConfigurationInfo
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ConfigurationInfoEntry'
+  /jobmanager/environment:
+    get:
+      description: Returns the jobmanager environment.
+      operationId: getJobManagerEnvironment
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvironmentInfo'
+  /jobmanager/logs:
+    get:
+      description: Returns the list of log files on the JobManager.
+      operationId: getJobManagerLogList
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogListInfo'
+  /jobmanager/metrics:
+    get:
+      description: Provides access to job manager metrics.
+      operationId: getJobManagerMetrics
+      parameters:
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /jobmanager/thread-dump:
+    get:
+      description: Returns the thread dump of the JobManager.
+      operationId: getJobManagerThreadDump
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadDumpInfo'
+  /jobs:
+    get:
+      description: Returns an overview over all jobs and their current state.
+      operationId: getJobIdsWithStatusesOverview
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobIdsWithStatusOverview'
+    post:
+      description: "Submits a job. This call is primarily intended to be used by the\
+        \ Flink client. This call expects a multipart/form-data request that consists\
+        \ of file uploads for the serialized JobGraph, jars and distributed cache\
+        \ artifacts and an attribute named \"request\" for the JSON payload."
+      operationId: submitJob
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                request:
+                  $ref: '#/components/schemas/JobSubmitRequestBody'
+                filename:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+        required: true
+      responses:
+        "202":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobSubmitResponseBody'
+  /jobs/metrics:
+    get:
+      description: Provides access to aggregated job metrics.
+      operationId: getAggregatedJobMetrics
+      parameters:
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: agg
+          in: query
+          description: "Comma-separated list of aggregation modes which should be calculated.\
+          \ Available aggregations are: \"min, max, sum, avg, skew\"."
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/AggregationMode'
+        - name: jobs
+          in: query
+          description: Comma-separated list of 32-character hexadecimal strings to select
+            specific jobs.
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AggregatedMetricsResponseBody'
+  /jobs/overview:
+    get:
+      description: Returns an overview over all jobs.
+      operationId: getJobsOverview
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipleJobsDetails'
+  /jobs/{jobid}:
+    get:
+      description: Returns details of a job.
+      operationId: getJobDetails
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobDetailsInfo'
+    patch:
+      description: Terminates a job.
+      operationId: cancelJob
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: mode
+          in: query
+          description: "String value that specifies the termination mode. The only supported\
+          \ value is: \"cancel\"."
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/TerminationMode'
+      responses:
+        "202":
+          description: The request was successful.
+  /jobs/{jobid}/accumulators:
+    get:
+      description: "Returns the accumulators for all tasks of a job, aggregated across\
+        \ the respective subtasks."
+      operationId: getJobAccumulators
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: includeSerializedValue
+          in: query
+          description: Boolean value that specifies whether serialized user task accumulators
+            should be included in the response.
+          required: false
+          style: form
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobAccumulatorsInfo'
+  /jobs/{jobid}/checkpoints:
+    get:
+      description: Returns checkpointing statistics for a job.
+      operationId: getCheckpointingStatistics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckpointingStatistics'
+    post:
+      description: Triggers a checkpoint. The 'checkpointType' parameter does not
+        support 'INCREMENTAL' option for now. See FLINK-33723. This async operation
+        would return a 'triggerid' for further query identifier.
+      operationId: triggerCheckpoint
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckpointTriggerRequestBody'
+      responses:
+        "202":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /jobs/{jobid}/checkpoints/config:
+    get:
+      description: Returns the checkpointing configuration.
+      operationId: getCheckpointConfig
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckpointConfigInfo'
+  /jobs/{jobid}/checkpoints/details/{checkpointid}:
+    get:
+      description: Returns details for a checkpoint.
+      operationId: getCheckpointStatisticDetails
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: checkpointid
+          in: path
+          description: Long value that identifies a checkpoint.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckpointStatistics'
+  /jobs/{jobid}/checkpoints/details/{checkpointid}/subtasks/{vertexid}:
+    get:
+      description: Returns checkpoint statistics for a task and its subtasks.
+      operationId: getTaskCheckpointStatistics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: checkpointid
+          in: path
+          description: Long value that identifies a checkpoint.
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskCheckpointStatisticsWithSubtaskDetails'
+  /jobs/{jobid}/checkpoints/{triggerid}:
+    get:
+      description: Returns the status of a checkpoint trigger operation.
+      operationId: getCheckpointStatus
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: triggerid
+          in: path
+          description: 32-character hexadecimal string that identifies an asynchronous
+            operation trigger ID. The ID was returned then the operation was triggered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TriggerId'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsynchronousOperationResult'
+  /jobs/{jobid}/clientHeartbeat:
+    patch:
+      description: Report the jobClient's aliveness.
+      operationId: triggerHeartbeat
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobClientHeartbeatRequestBody'
+      responses:
+        "202":
+          description: The request was successful.
+  /jobs/{jobid}/config:
+    get:
+      description: Returns the configuration of a job.
+      operationId: getJobConfig
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobConfigInfo'
+  /jobs/{jobid}/exceptions:
+    get:
+      description: "Returns the most recent exceptions that have been handled by Flink\
+        \ for this job. The 'exceptionHistory.truncated' flag defines whether exceptions\
+        \ were filtered out through the GET parameter. The backend collects only a\
+        \ specific amount of most recent exceptions per job. This can be configured\
+        \ through web.exception-history-size in the Flink configuration. The following\
+        \ first-level members are deprecated: 'root-exception', 'timestamp', 'all-exceptions',\
+        \ and 'truncated'. Use the data provided through 'exceptionHistory', instead."
+      operationId: getJobExceptions
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: maxExceptions
+          in: query
+          description: Comma-separated list of integer values that specifies the upper
+            limit of exceptions to return.
+          required: false
+          style: form
+          schema:
+            type: integer
+            format: int32
+        - name: failureLabelFilter
+          in: query
+          description: Collection of string values working as a filter in the form of
+            `key:value` pairs allowing only exceptions with ALL of the specified failure
+            labels to be returned.
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/FailureLabel'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobExceptionsInfoWithHistory'
+  /jobs/{jobid}/execution-result:
+    get:
+      description: Returns the result of a job execution. Gives access to the execution
+        time of the job and to all accumulators created by this job.
+      operationId: getJobExecutionResult
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobExecutionResultResponseBody'
+  /jobs/{jobid}/jobmanager/config:
+    get:
+      description: Returns the jobmanager's configuration of a specific job.
+      operationId: getJobManagerJobConfiguration
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ConfigurationInfoEntry'
+  /jobs/{jobid}/jobmanager/environment:
+    get:
+      description: Returns the jobmanager's environment of a specific job.
+      operationId: getJobManagerJobEnvironment
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvironmentInfo'
+  /jobs/{jobid}/jobmanager/log-url:
+    get:
+      description: Returns the log url of jobmanager of a specific job.
+      operationId: getJobManagerLogUrl
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogUrlResponse'
+  /jobs/{jobid}/metrics:
+    get:
+      description: Provides access to job metrics.
+      operationId: getJobMetrics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /jobs/{jobid}/plan:
+    get:
+      description: Returns the dataflow plan of a job.
+      operationId: getJobPlan
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobPlanInfo'
+  /jobs/{jobid}/rescaling:
+    patch:
+      description: Triggers the rescaling of a job. This async operation would return
+        a 'triggerid' for further query identifier.
+      operationId: rescaleJob
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: parallelism
+          in: query
+          description: Positive integer value that specifies the desired parallelism.
+          required: true
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /jobs/{jobid}/rescaling/{triggerid}:
+    get:
+      description: Returns the status of a rescaling operation.
+      operationId: getRescalingStatus
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: triggerid
+          in: path
+          description: 32-character hexadecimal string that identifies an asynchronous
+            operation trigger ID. The ID was returned then the operation was triggered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TriggerId'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsynchronousOperationResult'
+  /jobs/{jobid}/resource-requirements:
+    get:
+      description: Request details on the job's resource requirements.
+      operationId: getJobResourceRequirements
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResourceRequirementsBody'
+    put:
+      description: Request to update job's resource requirements.
+      operationId: updateJobResourceRequirements
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobResourceRequirementsBody'
+      responses:
+        "200":
+          description: The request was successful.
+  /jobs/{jobid}/savepoints:
+    post:
+      description: "Triggers a savepoint, and optionally cancels the job afterwards.\
+        \ This async operation would return a 'triggerid' for further query identifier."
+      operationId: triggerSavepoint
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavepointTriggerRequestBody'
+      responses:
+        "202":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /jobs/{jobid}/savepoints/{triggerid}:
+    get:
+      description: Returns the status of a savepoint operation.
+      operationId: getSavepointStatus
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: triggerid
+          in: path
+          description: 32-character hexadecimal string that identifies an asynchronous
+            operation trigger ID. The ID was returned then the operation was triggered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TriggerId'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsynchronousOperationResult'
+  /jobs/{jobid}/status:
+    get:
+      description: Returns the current status of a job execution.
+      operationId: getJobStatusInfo
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobStatusInfo'
+  /jobs/{jobid}/stop:
+    post:
+      description: "Stops a job with a savepoint. Optionally, it can also emit a MAX_WATERMARK\
+        \ before taking the savepoint to flush out any state waiting for timers to\
+        \ fire. This async operation would return a 'triggerid' for further query\
+        \ identifier."
+      operationId: triggerStopWithSavepoint
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StopWithSavepointRequestBody'
+      responses:
+        "202":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /jobs/{jobid}/taskmanagers/{taskmanagerid}/log-url:
+    get:
+      description: Returns the log url of jobmanager of a specific job.
+      operationId: getTaskManagerLogUrl
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: taskmanagerid
+          in: path
+          description: 32-character hexadecimal string that identifies a task manager.
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogUrlResponse'
+  /jobs/{jobid}/vertices/{vertexid}:
+    get:
+      description: "Returns details for a task, with a summary for each of its subtasks."
+      operationId: getJobVertexDetails
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobVertexDetailsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/accumulators:
+    get:
+      description: "Returns user-defined accumulators of a task, aggregated across\
+        \ all subtasks."
+      operationId: getJobVertexAccumulators
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobVertexAccumulatorsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/backpressure:
+    get:
+      description: "Returns back-pressure information for a job, and may initiate\
+        \ back-pressure sampling if necessary."
+      operationId: getJobVertexBackPressure
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobVertexBackPressureInfo'
+  /jobs/{jobid}/vertices/{vertexid}/flamegraph:
+    get:
+      description: "Returns flame graph information for a vertex, and may initiate\
+        \ flame graph sampling if necessary."
+      operationId: getJobVertexFlameGraph
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: type
+          in: query
+          description: "String value that specifies the Flame Graph type. Supported\
+          \ options are: \"[FULL, ON_CPU, OFF_CPU]\"."
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/ThreadStates'
+        - name: subtaskindex
+          in: query
+          description: Positive integer value that identifies a subtask.
+          required: false
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VertexFlameGraph'
+  /jobs/{jobid}/vertices/{vertexid}/jm-operator-metrics:
+    get:
+      description: Provides access to jobmanager operator metrics. This is an operator
+        that executes on the jobmanager and the coordinator for FLIP 27 sources is
+        one example of such an operator.
+      operationId: getJobManagerOperatorMetrics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /jobs/{jobid}/vertices/{vertexid}/metrics:
+    get:
+      description: Provides access to task metrics.
+      operationId: getJobVertexMetrics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/accumulators:
+    get:
+      description: Returns all user-defined accumulators for all subtasks of a task.
+      operationId: getSubtasksAllAccumulators
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubtasksAllAccumulatorsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/metrics:
+    get:
+      description: Provides access to aggregated subtask metrics.
+      operationId: getAggregatedSubtaskMetrics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: agg
+          in: query
+          description: "Comma-separated list of aggregation modes which should be calculated.\
+          \ Available aggregations are: \"min, max, sum, avg, skew\"."
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/AggregationMode'
+        - name: subtasks
+          in: query
+          description: "Comma-separated list of integer ranges (e.g. \"1,3,5-9\") to\
+          \ select specific subtasks."
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AggregatedMetricsResponseBody'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}:
+    get:
+      description: Returns details of the current or latest execution attempt of a
+        subtask.
+      operationId: getSubtaskCurrentAttemptDetails
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: subtaskindex
+          in: path
+          description: Positive integer value that identifies a subtask.
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubtaskExecutionAttemptDetailsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}/attempts/{attempt}:
+    get:
+      description: Returns details of an execution attempt of a subtask. Multiple
+        execution attempts happen in case of failure/recovery.
+      operationId: getSubtaskExecutionAttemptDetails
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: subtaskindex
+          in: path
+          description: Positive integer value that identifies a subtask.
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: attempt
+          in: path
+          description: Positive integer value that identifies an execution attempt.
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubtaskExecutionAttemptDetailsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}/attempts/{attempt}/accumulators:
+    get:
+      description: Returns the accumulators of an execution attempt of a subtask.
+        Multiple execution attempts happen in case of failure/recovery.
+      operationId: getSubtaskExecutionAttemptAccumulators
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: subtaskindex
+          in: path
+          description: Positive integer value that identifies a subtask.
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: attempt
+          in: path
+          description: Positive integer value that identifies an execution attempt.
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubtaskExecutionAttemptAccumulatorsInfo'
+  /jobs/{jobid}/vertices/{vertexid}/subtasks/{subtaskindex}/metrics:
+    get:
+      description: Provides access to subtask metrics.
+      operationId: getSubtaskMetrics
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+        - name: subtaskindex
+          in: path
+          description: Positive integer value that identifies a subtask.
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /jobs/{jobid}/vertices/{vertexid}/subtasktimes:
+    get:
+      description: Returns time-related information for all subtasks of a task.
+      operationId: getSubtasksTimes
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubtasksTimesInfo'
+  /jobs/{jobid}/vertices/{vertexid}/taskmanagers:
+    get:
+      description: Returns task information aggregated by task manager.
+      operationId: getJobVertexTaskManagers
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobVertexTaskManagersInfo'
+  /jobs/{jobid}/vertices/{vertexid}/watermarks:
+    get:
+      description: Returns the watermarks for all subtasks of a task.
+      operationId: getJobVertexWatermarks
+      parameters:
+        - name: jobid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobID'
+        - name: vertexid
+          in: path
+          description: 32-character hexadecimal string value that identifies a job vertex.
+          required: true
+          schema:
+            $ref: '#/components/schemas/JobVertexID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /overview:
+    get:
+      description: Returns an overview over the Flink cluster.
+      operationId: getClusterOverview
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterOverviewWithVersion'
+  /savepoint-disposal:
+    post:
+      description: Triggers the desposal of a savepoint. This async operation would
+        return a 'triggerid' for further query identifier.
+      operationId: triggerSavepointDisposal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavepointDisposalRequest'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerResponse'
+  /savepoint-disposal/{triggerid}:
+    get:
+      description: Returns the status of a savepoint disposal operation.
+      operationId: getSavepointDisposalStatus
+      parameters:
+        - name: triggerid
+          in: path
+          description: 32-character hexadecimal string that identifies an asynchronous
+            operation trigger ID. The ID was returned then the operation was triggered.
+          required: true
+          schema:
+            $ref: '#/components/schemas/TriggerId'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsynchronousOperationResult'
+  /taskmanagers:
+    get:
+      description: Returns an overview over all task managers.
+      operationId: getTaskManagers
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskManagersInfo'
+  /taskmanagers/metrics:
+    get:
+      description: Provides access to aggregated task manager metrics.
+      operationId: getAggregatedTaskManagerMetrics
+      parameters:
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+        - name: agg
+          in: query
+          description: "Comma-separated list of aggregation modes which should be calculated.\
+          \ Available aggregations are: \"min, max, sum, avg, skew\"."
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/AggregationMode'
+        - name: taskmanagers
+          in: query
+          description: Comma-separated list of 32-character hexadecimal strings to select
+            specific task managers.
+          required: false
+          style: form
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AggregatedMetricsResponseBody'
+  /taskmanagers/{taskmanagerid}:
+    get:
+      description: Returns details for a task manager. "metrics.memorySegmentsAvailable"
+        and "metrics.memorySegmentsTotal" are deprecated. Please use "metrics.nettyShuffleMemorySegmentsAvailable"
+        and "metrics.nettyShuffleMemorySegmentsTotal" instead.
+      operationId: getTaskManagerDetails
+      parameters:
+        - name: taskmanagerid
+          in: path
+          description: 32-character hexadecimal string that identifies a task manager.
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskManagerDetailsInfo'
+  /taskmanagers/{taskmanagerid}/logs:
+    get:
+      description: Returns the list of log files on a TaskManager.
+      operationId: getTaskManagerLogs
+      parameters:
+        - name: taskmanagerid
+          in: path
+          description: 32-character hexadecimal string that identifies a task manager.
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogListInfo'
+  /taskmanagers/{taskmanagerid}/metrics:
+    get:
+      description: Provides access to task manager metrics.
+      operationId: getTaskManagerMetrics
+      parameters:
+        - name: taskmanagerid
+          in: path
+          description: 32-character hexadecimal string that identifies a task manager.
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+        - name: get
+          in: query
+          description: Comma-separated list of string values to select specific metrics.
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricCollectionResponseBody'
+  /taskmanagers/{taskmanagerid}/thread-dump:
+    get:
+      description: Returns the thread dump of the requested TaskManager.
+      operationId: getTaskManagerThreadDump
+      parameters:
+        - name: taskmanagerid
+          in: path
+          description: 32-character hexadecimal string that identifies a task manager.
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceID'
+      responses:
+        "200":
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadDumpInfo'
+components:
+  schemas:
+    AggregatedMetricsResponseBody:
+      type: object
+    AggregatedTaskDetailsInfo:
+      type: object
+      properties:
+        metrics:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int64
+        status-duration:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int64
+    AggregationMode:
+      type: string
+      enum:
+        - MIN
+        - MAX
+        - SUM
+        - AVG
+        - SKEW
+    ApplicationStatus:
+      type: string
+      enum:
+        - SUCCEEDED
+        - FAILED
+        - CANCELED
+        - UNKNOWN
+    AsynchronousOperationInfo:
+      type: object
+      properties:
+        failure-cause:
+          $ref: '#/components/schemas/SerializedThrowable'
+    AsynchronousOperationResult:
+      type: object
+      properties:
+        operation:
+          oneOf:
+            - $ref: '#/components/schemas/AsynchronousOperationInfo'
+            - $ref: '#/components/schemas/CheckpointInfo'
+            - $ref: '#/components/schemas/SavepointInfo'
+        status:
+          $ref: '#/components/schemas/QueueStatus'
+    CheckpointAlignment:
+      type: object
+      properties:
+        buffered:
+          type: integer
+          format: int64
+        duration:
+          type: integer
+          format: int64
+        persisted:
+          type: integer
+          format: int64
+        processed:
+          type: integer
+          format: int64
+    CheckpointAlignmentSummary:
+      type: object
+      properties:
+        buffered:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        persisted:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        processed:
+          $ref: '#/components/schemas/StatsSummaryDto'
+    CheckpointConfigInfo:
+      type: object
+      properties:
+        aligned_checkpoint_timeout:
+          type: integer
+          format: int64
+        changelog_periodic_materialization_interval:
+          type: integer
+          format: int64
+        changelog_storage:
+          type: string
+        checkpoint_storage:
+          type: string
+        checkpoints_after_tasks_finish:
+          type: boolean
+        externalization:
+          $ref: '#/components/schemas/ExternalizedCheckpointInfo'
+        interval:
+          type: integer
+          format: int64
+        max_concurrent:
+          type: integer
+          format: int64
+        min_pause:
+          type: integer
+          format: int64
+        mode:
+          $ref: '#/components/schemas/ProcessingMode'
+        state_backend:
+          type: string
+        state_changelog_enabled:
+          type: boolean
+        timeout:
+          type: integer
+          format: int64
+        tolerable_failed_checkpoints:
+          type: integer
+          format: int32
+        unaligned_checkpoints:
+          type: boolean
+    CheckpointDuration:
+      type: object
+      properties:
+        async:
+          type: integer
+          format: int64
+        sync:
+          type: integer
+          format: int64
+    CheckpointDurationSummary:
+      type: object
+      properties:
+        async:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        sync:
+          $ref: '#/components/schemas/StatsSummaryDto'
+    CheckpointInfo:
+      type: object
+      properties:
+        checkpointId:
+          type: integer
+          format: int64
+        failureCause:
+          $ref: '#/components/schemas/SerializedThrowable'
+    CheckpointStatistics:
+      required:
+        - className
+      type: object
+      properties:
+        alignment_buffered:
+          type: integer
+          format: int64
+        checkpoint_type:
+          $ref: '#/components/schemas/RestAPICheckpointType'
+        checkpointed_size:
+          type: integer
+          format: int64
+        className:
+          type: string
+        end_to_end_duration:
+          type: integer
+          format: int64
+        id:
+          type: integer
+          format: int64
+        is_savepoint:
+          type: boolean
+        latest_ack_timestamp:
+          type: integer
+          format: int64
+        num_acknowledged_subtasks:
+          type: integer
+          format: int32
+        num_subtasks:
+          type: integer
+          format: int32
+        persisted_data:
+          type: integer
+          format: int64
+        processed_data:
+          type: integer
+          format: int64
+        savepointFormat:
+          type: string
+        state_size:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/CheckpointStatsStatus'
+        tasks:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/TaskCheckpointStatistics'
+        trigger_timestamp:
+          type: integer
+          format: int64
+      discriminator:
+        propertyName: className
+        mapping:
+          completed: '#/components/schemas/CompletedCheckpointStatistics'
+          failed: '#/components/schemas/FailedCheckpointStatistics'
+          in_progress: '#/components/schemas/PendingCheckpointStatistics'
+    CheckpointStatisticsSummary:
+      type: object
+      properties:
+        alignment_buffered:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        checkpointed_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        end_to_end_duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        persisted_data:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        processed_data:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        state_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+    CheckpointStatsStatus:
+      type: string
+      enum:
+        - IN_PROGRESS
+        - COMPLETED
+        - FAILED
+    CheckpointTriggerRequestBody:
+      type: object
+      properties:
+        checkpointType:
+          $ref: '#/components/schemas/CheckpointType'
+        triggerId:
+          $ref: '#/components/schemas/TriggerId'
+    CheckpointType:
+      type: string
+      enum:
+        - CONFIGURED
+        - FULL
+        - INCREMENTAL
+    CheckpointingStatistics:
+      type: object
+      properties:
+        counts:
+          $ref: '#/components/schemas/Counts'
+        history:
+          type: array
+          items:
+            $ref: '#/components/schemas/CheckpointStatistics'
+        latest:
+          $ref: '#/components/schemas/LatestCheckpoints'
+        summary:
+          $ref: '#/components/schemas/CheckpointStatisticsSummary'
+    ClusterDataSetEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        isComplete:
+          type: boolean
+    ClusterDataSetListResponseBody:
+      type: object
+      properties:
+        dataSets:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterDataSetEntry'
+    ClusterOverviewWithVersion:
+      type: object
+      properties:
+        flink-commit:
+          type: string
+        flink-version:
+          type: string
+        jobs-cancelled:
+          type: integer
+          format: int32
+        jobs-failed:
+          type: integer
+          format: int32
+        jobs-finished:
+          type: integer
+          format: int32
+        jobs-running:
+          type: integer
+          format: int32
+        slots-available:
+          type: integer
+          format: int32
+        slots-free-and-blocked:
+          type: integer
+          format: int32
+        slots-total:
+          type: integer
+          format: int32
+        taskmanagers:
+          type: integer
+          format: int32
+        taskmanagers-blocked:
+          type: integer
+          format: int32
+    CompletedCheckpointStatistics:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/CheckpointStatistics'
+        - type: object
+          properties:
+            external_path:
+              type: string
+            discarded:
+              type: boolean
+    CompletedSubtaskCheckpointStatistics:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/SubtaskCheckpointStatistics'
+        - type: object
+          properties:
+            ack_timestamp:
+              type: integer
+              format: int64
+            end_to_end_duration:
+              type: integer
+              format: int64
+            checkpointed_size:
+              type: integer
+              format: int64
+            state_size:
+              type: integer
+              format: int64
+            checkpoint:
+              $ref: '#/components/schemas/CheckpointDuration'
+            alignment:
+              $ref: '#/components/schemas/CheckpointAlignment'
+            start_delay:
+              type: integer
+              format: int64
+            unaligned_checkpoint:
+              type: boolean
+            aborted:
+              type: boolean
+    ConfigurationInfo:
+      type: array
+      items:
+        $ref: '#/components/schemas/ConfigurationInfoEntry'
+    ConfigurationInfoEntry:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    Counts:
+      type: object
+      properties:
+        completed:
+          type: integer
+          format: int64
+        failed:
+          type: integer
+          format: int64
+        in_progress:
+          type: integer
+          format: int32
+        restored:
+          type: integer
+          format: int64
+        total:
+          type: integer
+          format: int64
+    DashboardConfiguration:
+      type: object
+      properties:
+        features:
+          $ref: '#/components/schemas/Features'
+        flink-revision:
+          type: string
+        flink-version:
+          type: string
+        refresh-interval:
+          type: integer
+          format: int64
+        timezone-name:
+          type: string
+        timezone-offset:
+          type: integer
+          format: int32
+    DistributedCacheFile:
+      type: object
+      properties:
+        entryName:
+          type: string
+        fileName:
+          type: string
+    EnvironmentInfo:
+      type: object
+      properties:
+        classpath:
+          type: array
+          items:
+            type: string
+        jvm:
+          $ref: '#/components/schemas/JVMInfo'
+    ExceptionInfo:
+      type: object
+      properties:
+        endpoint:
+          type: string
+        exceptionName:
+          type: string
+        failureLabels:
+          type: object
+          additionalProperties:
+            type: string
+        location:
+          type: string
+        stacktrace:
+          type: string
+        taskManagerId:
+          type: string
+        taskName:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+    ExecutionConfigInfo:
+      type: object
+      properties:
+        execution-mode:
+          type: string
+        job-parallelism:
+          type: integer
+          format: int32
+        object-reuse-mode:
+          type: boolean
+        restart-strategy:
+          type: string
+        user-config:
+          type: object
+          additionalProperties:
+            type: string
+    ExecutionExceptionInfo:
+      type: object
+      properties:
+        endpoint:
+          type: string
+        exception:
+          type: string
+        location:
+          type: string
+        task:
+          type: string
+        taskManagerId:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+    ExecutionState:
+      type: string
+      enum:
+        - CREATED
+        - SCHEDULED
+        - DEPLOYING
+        - RUNNING
+        - FINISHED
+        - CANCELING
+        - CANCELED
+        - FAILED
+        - RECONCILING
+        - INITIALIZING
+    ExternalizedCheckpointInfo:
+      type: object
+      properties:
+        delete_on_cancellation:
+          type: boolean
+        enabled:
+          type: boolean
+    FailedCheckpointStatistics:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/CheckpointStatistics'
+        - type: object
+          properties:
+            failure_timestamp:
+              type: integer
+              format: int64
+            failure_message:
+              type: string
+    FailureLabel:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    Features:
+      type: object
+      properties:
+        web-cancel:
+          type: boolean
+        web-history:
+          type: boolean
+        web-rescale:
+          type: boolean
+        web-submit:
+          type: boolean
+    GarbageCollectorInfo:
+      type: object
+      properties:
+        count:
+          type: integer
+          format: int64
+        name:
+          type: string
+        time:
+          type: integer
+          format: int64
+    HardwareDescription:
+      type: object
+      properties:
+        cpuCores:
+          type: integer
+          format: int32
+        freeMemory:
+          type: integer
+          format: int64
+        managedMemory:
+          type: integer
+          format: int64
+        physicalMemory:
+          type: integer
+          format: int64
+    IOMetricsInfo:
+      type: object
+      properties:
+        accumulated-backpressured-time:
+          type: integer
+          format: int64
+        accumulated-busy-time:
+          type: number
+          format: double
+        accumulated-idle-time:
+          type: integer
+          format: int64
+        read-bytes:
+          type: integer
+          format: int64
+        read-bytes-complete:
+          type: boolean
+        read-records:
+          type: integer
+          format: int64
+        read-records-complete:
+          type: boolean
+        write-bytes:
+          type: integer
+          format: int64
+        write-bytes-complete:
+          type: boolean
+        write-records:
+          type: integer
+          format: int64
+        write-records-complete:
+          type: boolean
+    Id:
+      type: string
+      enum:
+        - IN_PROGRESS
+        - COMPLETED
+    IntermediateDataSetID:
+      pattern: "[0-9a-f]{32}"
+      type: string
+    JVMInfo:
+      type: object
+      properties:
+        arch:
+          type: string
+        options:
+          type: array
+          items:
+            type: string
+        version:
+          type: string
+    JarEntryInfo:
+      type: object
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+    JarFileInfo:
+      type: object
+      properties:
+        entry:
+          type: array
+          items:
+            $ref: '#/components/schemas/JarEntryInfo'
+        id:
+          type: string
+        name:
+          type: string
+        uploaded:
+          type: integer
+          format: int64
+    JarListInfo:
+      type: object
+      properties:
+        address:
+          type: string
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/JarFileInfo'
+    JarPlanRequestBody:
+      type: object
+      properties:
+        entryClass:
+          type: string
+        flinkConfiguration:
+          type: object
+          additionalProperties:
+            type: string
+        jobId:
+          $ref: '#/components/schemas/JobID'
+        parallelism:
+          type: integer
+          format: int32
+        programArgs:
+          type: string
+        programArgsList:
+          type: array
+          items:
+            type: string
+    JarRunRequestBody:
+      type: object
+      properties:
+        allowNonRestoredState:
+          type: boolean
+        claimMode:
+          $ref: '#/components/schemas/RestoreMode'
+        entryClass:
+          type: string
+        flinkConfiguration:
+          type: object
+          additionalProperties:
+            type: string
+        jobId:
+          $ref: '#/components/schemas/JobID'
+        parallelism:
+          type: integer
+          format: int32
+        programArgs:
+          type: string
+        programArgsList:
+          type: array
+          items:
+            type: string
+        restoreMode:
+          $ref: '#/components/schemas/RestoreMode'
+        savepointPath:
+          type: string
+    JarRunResponseBody:
+      type: object
+      properties:
+        jobid:
+          $ref: '#/components/schemas/JobID'
+    JarUploadResponseBody:
+      type: object
+      properties:
+        filename:
+          type: string
+        status:
+          $ref: '#/components/schemas/UploadStatus'
+    JobAccumulator:
+      type: object
+    JobAccumulatorsInfo:
+      type: object
+      properties:
+        job-accumulators:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobAccumulator'
+        serialized-user-task-accumulators:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/SerializedValueOptionalFailureObject'
+        user-task-accumulators:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserTaskAccumulator'
+    JobClientHeartbeatRequestBody:
+      type: object
+      properties:
+        expiredTimestamp:
+          type: integer
+          format: int64
+    JobConfigInfo:
+      type: object
+      properties:
+        executionConfigInfo:
+          $ref: '#/components/schemas/ExecutionConfigInfo'
+        jobId:
+          $ref: '#/components/schemas/JobID'
+        jobName:
+          type: string
+    JobDetails:
+      type: object
+      properties:
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        jid:
+          $ref: '#/components/schemas/JobID'
+        last-modification:
+          type: integer
+          format: int64
+        name:
+          type: string
+        start-time:
+          type: integer
+          format: int64
+        state:
+          $ref: '#/components/schemas/JobStatus'
+        tasks:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+    JobDetailsInfo:
+      type: object
+      properties:
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        isStoppable:
+          type: boolean
+        jid:
+          $ref: '#/components/schemas/JobID'
+        job-type:
+          $ref: '#/components/schemas/JobType'
+        maxParallelism:
+          type: integer
+          format: int64
+        name:
+          type: string
+        now:
+          type: integer
+          format: int64
+        plan:
+          $ref: '#/components/schemas/RawJson'
+        start-time:
+          type: integer
+          format: int64
+        state:
+          $ref: '#/components/schemas/JobStatus'
+        status-counts:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        timestamps:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+        vertices:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobDetailsVertexInfo'
+    JobDetailsVertexInfo:
+      type: object
+      properties:
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        id:
+          $ref: '#/components/schemas/JobVertexID'
+        maxParallelism:
+          type: integer
+          format: int32
+        metrics:
+          $ref: '#/components/schemas/IOMetricsInfo'
+        name:
+          type: string
+        parallelism:
+          type: integer
+          format: int32
+        slotSharingGroupId:
+          $ref: '#/components/schemas/SlotSharingGroupId'
+        start-time:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        tasks:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+    JobExceptionHistory:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RootExceptionInfo'
+        truncated:
+          type: boolean
+    JobExceptionsInfoWithHistory:
+      type: object
+      properties:
+        all-exceptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionExceptionInfo'
+        exceptionHistory:
+          $ref: '#/components/schemas/JobExceptionHistory'
+        root-exception:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+        truncated:
+          type: boolean
+    JobExecutionResultResponseBody:
+      required:
+        - status
+      type: object
+      properties:
+        job-execution-result:
+          $ref: '#/components/schemas/JobResult'
+        status:
+          $ref: '#/components/schemas/QueueStatus'
+    JobID:
+      pattern: "[0-9a-f]{32}"
+      type: string
+    JobIdWithStatus:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/JobID'
+        status:
+          $ref: '#/components/schemas/JobStatus'
+    JobIdsWithStatusOverview:
+      type: object
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobIdWithStatus'
+    JobPlanInfo:
+      type: object
+      properties:
+        plan:
+          $ref: '#/components/schemas/RawJson'
+    JobResourceRequirementsBody:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/JobVertexResourceRequirements'
+    JobResult:
+      type: object
+      properties:
+        accumulatorResults:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/SerializedValueOptionalFailureObject'
+        applicationStatus:
+          $ref: '#/components/schemas/ApplicationStatus'
+        jobId:
+          $ref: '#/components/schemas/JobID'
+        netRuntime:
+          type: integer
+          format: int64
+        serializedThrowable:
+          $ref: '#/components/schemas/SerializedThrowable'
+        success:
+          type: boolean
+    JobStatus:
+      type: string
+      enum:
+        - INITIALIZING
+        - CREATED
+        - RUNNING
+        - FAILING
+        - FAILED
+        - CANCELLING
+        - CANCELED
+        - FINISHED
+        - RESTARTING
+        - SUSPENDED
+        - RECONCILING
+    JobStatusInfo:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/JobStatus'
+    JobSubmitRequestBody:
+      type: object
+      properties:
+        jobArtifactFileNames:
+          type: array
+          items:
+            $ref: '#/components/schemas/DistributedCacheFile'
+        jobGraphFileName:
+          type: string
+        jobJarFileNames:
+          type: array
+          items:
+            type: string
+    JobSubmitResponseBody:
+      type: object
+      properties:
+        jobUrl:
+          type: string
+    JobType:
+      type: string
+      enum:
+        - BATCH
+        - STREAMING
+    JobVertexAccumulatorsInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        user-accumulators:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserAccumulator'
+    JobVertexBackPressureInfo:
+      type: object
+      properties:
+        backpressureLevel:
+          $ref: '#/components/schemas/VertexBackPressureLevel'
+        end-timestamp:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/VertexBackPressureStatus'
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskBackPressureInfo'
+    JobVertexDetailsInfo:
+      type: object
+      properties:
+        aggregated:
+          $ref: '#/components/schemas/AggregatedTaskDetailsInfo'
+        id:
+          $ref: '#/components/schemas/JobVertexID'
+        maxParallelism:
+          type: integer
+          format: int32
+        name:
+          type: string
+        now:
+          type: integer
+          format: int64
+        parallelism:
+          type: integer
+          format: int32
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskExecutionAttemptDetailsInfo'
+    JobVertexID:
+      pattern: "[0-9a-f]{32}"
+      type: string
+    JobVertexResourceRequirements:
+      type: object
+      properties:
+        parallelism:
+          $ref: '#/components/schemas/Parallelism'
+    JobVertexTaskManagerInfo:
+      type: object
+      properties:
+        aggregated:
+          $ref: '#/components/schemas/AggregatedTaskDetailsInfo'
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        endpoint:
+          type: string
+        host:
+          type: string
+        metrics:
+          $ref: '#/components/schemas/IOMetricsInfo'
+        start-time:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        status-counts:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        taskmanager-id:
+          type: string
+    JobVertexTaskManagersInfo:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/JobVertexID'
+        name:
+          type: string
+        now:
+          type: integer
+          format: int64
+        taskmanagers:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobVertexTaskManagerInfo'
+    LatestCheckpoints:
+      type: object
+      properties:
+        completed:
+          $ref: '#/components/schemas/CompletedCheckpointStatistics'
+        failed:
+          $ref: '#/components/schemas/FailedCheckpointStatistics'
+        restored:
+          $ref: '#/components/schemas/RestoredCheckpointStatistics'
+        savepoint:
+          $ref: '#/components/schemas/CompletedCheckpointStatistics'
+    LogInfo:
+      type: object
+      properties:
+        mtime:
+          type: integer
+          format: int64
+        name:
+          type: string
+        size:
+          type: integer
+          format: int64
+    LogListInfo:
+      type: object
+      properties:
+        logs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogInfo'
+    LogUrlResponse:
+      type: object
+      properties:
+        url:
+          type: string
+    Metric:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: string
+        value:
+          type: string
+    MetricCollectionResponseBody:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Metric'
+    MultipleJobsDetails:
+      type: object
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobDetails'
+    Node:
+      type: object
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+        name:
+          type: string
+        value:
+          type: integer
+          format: int32
+    Parallelism:
+      type: object
+      properties:
+        lowerBound:
+          type: integer
+          format: int32
+        upperBound:
+          type: integer
+          format: int32
+    PendingCheckpointStatistics:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/CheckpointStatistics'
+    PendingSubtaskCheckpointStatistics:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/SubtaskCheckpointStatistics'
+    ProcessingMode:
+      type: string
+      enum:
+        - AT_LEAST_ONCE
+        - EXACTLY_ONCE
+    QueueStatus:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+    RawJson:
+      type: object
+    ResourceID:
+      pattern: "[0-9a-f]{32}"
+      type: string
+    ResourceProfileInfo:
+      type: object
+      properties:
+        cpuCores:
+          type: number
+          format: double
+        extendedResources:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+        managedMemory:
+          type: integer
+          format: int32
+        networkMemory:
+          type: integer
+          format: int32
+        taskHeapMemory:
+          type: integer
+          format: int32
+        taskOffHeapMemory:
+          type: integer
+          format: int32
+    RestAPICheckpointType:
+      type: string
+      enum:
+        - CHECKPOINT
+        - UNALIGNED_CHECKPOINT
+        - SAVEPOINT
+        - SYNC_SAVEPOINT
+    RestoreMode:
+      type: string
+      enum:
+        - CLAIM
+        - NO_CLAIM
+        - LEGACY
+    RestoredCheckpointStatistics:
+      type: object
+      properties:
+        external_path:
+          type: string
+        id:
+          type: integer
+          format: int64
+        is_savepoint:
+          type: boolean
+        restore_timestamp:
+          type: integer
+          format: int64
+    RootExceptionInfo:
+      type: object
+      properties:
+        concurrentExceptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExceptionInfo'
+        endpoint:
+          type: string
+        exceptionName:
+          type: string
+        failureLabels:
+          type: object
+          additionalProperties:
+            type: string
+        location:
+          type: string
+        stacktrace:
+          type: string
+        taskManagerId:
+          type: string
+        taskName:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+    SavepointDisposalRequest:
+      type: object
+      properties:
+        savepoint-path:
+          type: string
+    SavepointFormatType:
+      type: string
+      enum:
+        - CANONICAL
+        - NATIVE
+    SavepointInfo:
+      type: object
+      properties:
+        failure-cause:
+          $ref: '#/components/schemas/SerializedThrowable'
+        location:
+          type: string
+    SavepointTriggerRequestBody:
+      type: object
+      properties:
+        cancel-job:
+          type: boolean
+        formatType:
+          $ref: '#/components/schemas/SavepointFormatType'
+        target-directory:
+          type: string
+        triggerId:
+          $ref: '#/components/schemas/TriggerId'
+    SerializedThrowable:
+      type: object
+      properties:
+        serialized-throwable:
+          type: string
+          format: binary
+    SerializedValueOptionalFailureObject:
+      type: object
+      properties:
+        byteArray:
+          type: array
+          items:
+            type: string
+            format: byte
+    SlotInfo:
+      type: object
+      properties:
+        jobId:
+          $ref: '#/components/schemas/JobID'
+        resource:
+          $ref: '#/components/schemas/ResourceProfileInfo'
+    SlotSharingGroupId:
+      type: object
+      properties:
+        bytes:
+          type: array
+          items:
+            type: string
+            format: byte
+        lowerPart:
+          type: integer
+          format: int64
+        upperPart:
+          type: integer
+          format: int64
+    StatsSummaryDto:
+      type: object
+      properties:
+        avg:
+          type: integer
+          format: int64
+        max:
+          type: integer
+          format: int64
+        min:
+          type: integer
+          format: int64
+        p50:
+          type: number
+          format: double
+        p90:
+          type: number
+          format: double
+        p95:
+          type: number
+          format: double
+        p99:
+          type: number
+          format: double
+        p999:
+          type: number
+          format: double
+    StopWithSavepointRequestBody:
+      type: object
+      properties:
+        drain:
+          type: boolean
+        formatType:
+          $ref: '#/components/schemas/SavepointFormatType'
+        targetDirectory:
+          type: string
+        triggerId:
+          $ref: '#/components/schemas/TriggerId'
+    SubtaskAccumulatorsInfo:
+      type: object
+      properties:
+        attempt:
+          type: integer
+          format: int32
+        endpoint:
+          type: string
+        host:
+          type: string
+        subtask:
+          type: integer
+          format: int32
+        user-accumulators:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserAccumulator'
+    SubtaskBackPressureInfo:
+      type: object
+      properties:
+        attempt-number:
+          type: integer
+          format: int32
+        backpressureLevel:
+          $ref: '#/components/schemas/VertexBackPressureLevel'
+        busyRatio:
+          type: number
+          format: double
+        idleRatio:
+          type: number
+          format: double
+        other-concurrent-attempts:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskBackPressureInfo'
+        ratio:
+          type: number
+          format: double
+        subtask:
+          type: integer
+          format: int32
+    SubtaskCheckpointStatistics:
+      required:
+        - className
+      type: object
+      properties:
+        className:
+          type: string
+        index:
+          type: integer
+          format: int32
+        status:
+          type: string
+      discriminator:
+        propertyName: className
+        mapping:
+          completed: '#/components/schemas/CompletedSubtaskCheckpointStatistics'
+          pending: '#/components/schemas/PendingSubtaskCheckpointStatistics'
+    SubtaskExecutionAttemptAccumulatorsInfo:
+      type: object
+      properties:
+        attempt:
+          type: integer
+          format: int32
+        id:
+          type: string
+        subtask:
+          type: integer
+          format: int32
+        user-accumulators:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserAccumulator'
+    SubtaskExecutionAttemptDetailsInfo:
+      type: object
+      properties:
+        attempt:
+          type: integer
+          format: int32
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        endpoint:
+          type: string
+        host:
+          type: string
+        metrics:
+          $ref: '#/components/schemas/IOMetricsInfo'
+        other-concurrent-attempts:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskExecutionAttemptDetailsInfo'
+        start-time:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        status-duration:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+        subtask:
+          type: integer
+          format: int32
+        taskmanager-id:
+          type: string
+    SubtaskTimeInfo:
+      type: object
+      properties:
+        duration:
+          type: integer
+          format: int64
+        endpoint:
+          type: string
+        host:
+          type: string
+        subtask:
+          type: integer
+          format: int32
+        timestamps:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+    SubtasksAllAccumulatorsInfo:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/JobVertexID'
+        parallelism:
+          type: integer
+          format: int32
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskAccumulatorsInfo'
+    SubtasksTimesInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        now:
+          type: integer
+          format: int64
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskTimeInfo'
+    TaskCheckpointStatistics:
+      type: object
+      properties:
+        alignment_buffered:
+          type: integer
+          format: int64
+        checkpointed_size:
+          type: integer
+          format: int64
+        end_to_end_duration:
+          type: integer
+          format: int64
+        id:
+          type: integer
+          format: int64
+        latest_ack_timestamp:
+          type: integer
+          format: int64
+        num_acknowledged_subtasks:
+          type: integer
+          format: int32
+        num_subtasks:
+          type: integer
+          format: int32
+        persisted_data:
+          type: integer
+          format: int64
+        processed_data:
+          type: integer
+          format: int64
+        state_size:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/CheckpointStatsStatus'
+    TaskCheckpointStatisticsWithSubtaskDetails:
+      type: object
+      properties:
+        alignment_buffered:
+          type: integer
+          format: int64
+        checkpointed_size:
+          type: integer
+          format: int64
+        end_to_end_duration:
+          type: integer
+          format: int64
+        id:
+          type: integer
+          format: int64
+        latest_ack_timestamp:
+          type: integer
+          format: int64
+        num_acknowledged_subtasks:
+          type: integer
+          format: int32
+        num_subtasks:
+          type: integer
+          format: int32
+        persisted_data:
+          type: integer
+          format: int64
+        processed_data:
+          type: integer
+          format: int64
+        state_size:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/CheckpointStatsStatus'
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubtaskCheckpointStatistics'
+        summary:
+          $ref: '#/components/schemas/TaskCheckpointStatisticsWithSubtaskDetailsSummary'
+    TaskCheckpointStatisticsWithSubtaskDetailsSummary:
+      type: object
+      properties:
+        alignment:
+          $ref: '#/components/schemas/CheckpointAlignmentSummary'
+        checkpoint_duration:
+          $ref: '#/components/schemas/CheckpointDurationSummary'
+        checkpointed_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        end_to_end_duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        start_delay:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        state_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+    TaskExecutorMemoryConfiguration:
+      type: object
+      properties:
+        frameworkHeap:
+          type: integer
+          format: int64
+        frameworkOffHeap:
+          type: integer
+          format: int64
+        jvmMetaspace:
+          type: integer
+          format: int64
+        jvmOverhead:
+          type: integer
+          format: int64
+        managedMemory:
+          type: integer
+          format: int64
+        networkMemory:
+          type: integer
+          format: int64
+        taskHeap:
+          type: integer
+          format: int64
+        taskOffHeap:
+          type: integer
+          format: int64
+        totalFlinkMemory:
+          type: integer
+          format: int64
+        totalProcessMemory:
+          type: integer
+          format: int64
+    TaskManagerDetailsInfo:
+      type: object
+      properties:
+        allocatedSlots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlotInfo'
+        blocked:
+          type: boolean
+        dataPort:
+          type: integer
+          format: int32
+        freeResource:
+          $ref: '#/components/schemas/ResourceProfileInfo'
+        freeSlots:
+          type: integer
+          format: int32
+        hardware:
+          $ref: '#/components/schemas/HardwareDescription'
+        id:
+          $ref: '#/components/schemas/ResourceID'
+        jmxPort:
+          type: integer
+          format: int32
+        memoryConfiguration:
+          $ref: '#/components/schemas/TaskExecutorMemoryConfiguration'
+        metrics:
+          $ref: '#/components/schemas/TaskManagerMetricsInfo'
+        path:
+          type: string
+        slotsNumber:
+          type: integer
+          format: int32
+        timeSinceLastHeartbeat:
+          type: integer
+          format: int64
+        totalResource:
+          $ref: '#/components/schemas/ResourceProfileInfo'
+    TaskManagerInfo:
+      type: object
+      properties:
+        blocked:
+          type: boolean
+        dataPort:
+          type: integer
+          format: int32
+        freeResource:
+          $ref: '#/components/schemas/ResourceProfileInfo'
+        freeSlots:
+          type: integer
+          format: int32
+        hardware:
+          $ref: '#/components/schemas/HardwareDescription'
+        id:
+          $ref: '#/components/schemas/ResourceID'
+        jmxPort:
+          type: integer
+          format: int32
+        memoryConfiguration:
+          $ref: '#/components/schemas/TaskExecutorMemoryConfiguration'
+        path:
+          type: string
+        slotsNumber:
+          type: integer
+          format: int32
+        timeSinceLastHeartbeat:
+          type: integer
+          format: int64
+        totalResource:
+          $ref: '#/components/schemas/ResourceProfileInfo'
+    TaskManagerMetricsInfo:
+      type: object
+      properties:
+        directCount:
+          type: integer
+          format: int64
+        directMax:
+          type: integer
+          format: int64
+        directUsed:
+          type: integer
+          format: int64
+        garbageCollectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/GarbageCollectorInfo'
+        heapCommitted:
+          type: integer
+          format: int64
+        heapMax:
+          type: integer
+          format: int64
+        heapUsed:
+          type: integer
+          format: int64
+        mappedCount:
+          type: integer
+          format: int64
+        mappedMax:
+          type: integer
+          format: int64
+        mappedUsed:
+          type: integer
+          format: int64
+        memorySegmentsAvailable:
+          type: integer
+          format: int64
+        memorySegmentsTotal:
+          type: integer
+          format: int64
+        nettyShuffleMemoryAvailable:
+          type: integer
+          format: int64
+        nettyShuffleMemorySegmentsAvailable:
+          type: integer
+          format: int64
+        nettyShuffleMemorySegmentsTotal:
+          type: integer
+          format: int64
+        nettyShuffleMemorySegmentsUsed:
+          type: integer
+          format: int64
+        nettyShuffleMemoryTotal:
+          type: integer
+          format: int64
+        nettyShuffleMemoryUsed:
+          type: integer
+          format: int64
+        nonHeapCommitted:
+          type: integer
+          format: int64
+        nonHeapMax:
+          type: integer
+          format: int64
+        nonHeapUsed:
+          type: integer
+          format: int64
+    TaskManagersInfo:
+      type: object
+      properties:
+        taskmanagers:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaskManagerInfo'
+    TerminationMode:
+      type: string
+      enum:
+        - CANCEL
+        - STOP
+    ThreadDumpInfo:
+      type: object
+      properties:
+        threadInfos:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThreadInfo'
+    ThreadInfo:
+      type: object
+      properties:
+        stringifiedThreadInfo:
+          type: string
+        threadName:
+          type: string
+    ThreadStates:
+      type: string
+      enum:
+        - FULL
+        - ON_CPU
+        - OFF_CPU
+    TriggerId:
+      pattern: "[0-9a-f]{32}"
+      type: string
+    TriggerResponse:
+      type: object
+      properties:
+        request-id:
+          $ref: '#/components/schemas/TriggerId'
+    UploadStatus:
+      type: string
+      enum:
+        - success
+    UserAccumulator:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+    UserTaskAccumulator:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+    VertexBackPressureLevel:
+      type: string
+      enum:
+        - ok
+        - low
+        - high
+    VertexBackPressureStatus:
+      type: string
+      enum:
+        - deprecated
+        - ok
+    VertexFlameGraph:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Node'
+        endTimestamp:
+          type: integer
+          format: int64


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

In this PR, we add a WARN to the logs when the OpenAPI file has duplicated element variables. For example:

```yaml
    CheckpointInfo:
      type: object
      properties:
        checkpointId:
          type: integer
          format: int64
        failureCause:
          $ref: '#/components/schemas/SerializedThrowable'
    SavepointInfo:
      type: object
      properties:
        failure-cause:
          $ref: '#/components/schemas/SerializedThrowable'
        location:
          type: string
```

Will fail because `failure-cause` and `failureCause` are the same variables from the Java syntax perspective as soon as we convert both to CamelCase.

**Why not remove the duplicates?**

Because users will only realize this bug in runtime when it's too late, and Json marshaling won't work:

```java
        /**
        * Get failureCause
        * @return failureCause
        **/
        @com.fasterxml.jackson.annotation.JsonProperty("failure-cause")
        public SerializedThrowable getFailureCause() {
            return failureCause;
        }

        /**
        * Get failureCause
        * @return failureCause
        **/
        @com.fasterxml.jackson.annotation.JsonProperty("failureCause")
        public SerializedThrowable getFailureCause() {
            return failureCause;
        }
```

Users should fix the OpenAPI spec on their side to have a healthy codegen.

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
