### PR TITLE
Consistently use `quarkus-generator.openApiSpecId` as openApiSpecId in templates

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
@@ -22,7 +22,7 @@ package {apiPackage}.auth;
 public class CompositeAuthenticationProvider implements jakarta.ws.rs.client.ClientRequestFilter {
 
     @jakarta.inject.Inject
-    @io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{configKey}")
+    @io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{quarkus-generator.openApiSpecId}")
     io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider compositeProvider;
 
     @java.lang.Override

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/auth/headersFactory.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/auth/headersFactory.qute
@@ -3,7 +3,7 @@ package {apiPackage}.auth;
 public class AuthenticationPropagationHeadersFactory extends io.quarkiverse.openapi.generator.providers.AbstractAuthenticationPropagationHeadersFactory {
 
     @jakarta.inject.Inject
-    public AuthenticationPropagationHeadersFactory(@io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{configKey}") io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider compositeProvider, io.quarkiverse.openapi.generator.OpenApiGeneratorConfig generatorConfig, io.quarkiverse.openapi.generator.providers.HeadersProvider headersProvider) {
+    public AuthenticationPropagationHeadersFactory(@io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{quarkus-generator.openApiSpecId}") io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider compositeProvider, io.quarkiverse.openapi.generator.OpenApiGeneratorConfig generatorConfig, io.quarkiverse.openapi.generator.providers.HeadersProvider headersProvider) {
         super(compositeProvider, generatorConfig, headersProvider);
     }
 


### PR DESCRIPTION
As otherwise using the `configKey` instead can lead to a mismatch and an exception like:

```
[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate threw an exception: jakarta.enterprise.inject.spi.DeploymentException: jakarta.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider and qualifiers [@OpenApiSpec(openApiSpecId = "your-config-key-not-the-same-as-spec-id")]
        - injection target: parameter 'compositeProvider' of com.acme.api.auth.AuthenticationPropagationHeadersFactory constructor
        - declared on CLASS bean [types=[com.acme.api.auth.AuthenticationPropagationHeadersFactory, io.quarkiverse.openapi.generator.providers.AbstractAuthenticationPropagationHeadersFactory, org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory, java.lang.Object], qualifiers=[@Default, @Any], target=com.acme.api.auth.AuthenticationPropagationHeadersFactory]
        The following beans match by type, but none has matching qualifiers:
        - SYNTHETIC bean [types=[io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider, java.lang.Object], qualifiers=[@Any, @io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId = "your-spec-id-not-the-same-as-config-key")], target=n/a]
```

This is related to the changes introduced in https://github.com/quarkiverse/quarkus-openapi-generator/pull/795 and discovered while trying to update to the 2.6.0 in the hibernate-github-bot (https://github.com/hibernate/hibernate-github-bot/actions/runs/11771089053/job/32792519558?pr=286).

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ ] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
