### PR TITLE
Link to extension guide on the extensions site

### DIFF
--- a/client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,7 @@ metadata:
     - "rest-client"
   categories:
     - "web"
+  guide: "https://docs.quarkiverse.io/quarkus-openapi-generator/dev/index.html"
   icon-url: "https://raw.githubusercontent.com/quarkiverse/quarkus-openapi-generator/main/docs/modules/ROOT/assets/images/openapi.svg"
   status: "preview"
   codestart:


### PR DESCRIPTION
Add missing link for the guide to the extensions page.

https://quarkus.io/extensions/io.quarkiverse.openapi.generator/quarkus-openapi-generator/