### PR TITLE
NO-ISSUE: Upgrade WireMock to `3.9.2`; Add Jboss RestEasy Multipart to IT

### DIFF
--- a/client/integration-tests/beanparam/pom.xml
+++ b/client/integration-tests/beanparam/pom.xml
@@ -27,8 +27,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/integration-tests/change-custom-template-directory/pom.xml
+++ b/client/integration-tests/change-custom-template-directory/pom.xml
@@ -20,8 +20,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client/integration-tests/change-directory/pom.xml
+++ b/client/integration-tests/change-directory/pom.xml
@@ -20,8 +20,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client/integration-tests/cookie-authentication/pom.xml
+++ b/client/integration-tests/cookie-authentication/pom.xml
@@ -28,8 +28,8 @@
         </dependency>
       
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/integration-tests/enum-property/pom.xml
+++ b/client/integration-tests/enum-property/pom.xml
@@ -27,8 +27,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/integration-tests/enum-property/src/test/java/io/quarkiverse/openapi/generator/it/EnumPropertyTest.java
+++ b/client/integration-tests/enum-property/src/test/java/io/quarkiverse/openapi/generator/it/EnumPropertyTest.java
@@ -20,7 +20,6 @@ import org.openapi.quarkus.enum_property_yaml.model.MessageNum;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -67,8 +66,7 @@ class EnumPropertyTest {
         }
 
         private void configureWiremockServer() {
-            var wireMockConfiguration = WireMockConfiguration.wireMockConfig()
-                    .extensions(new ResponseTemplateTransformer(false)).dynamicPort();
+            var wireMockConfiguration = WireMockConfiguration.wireMockConfig().dynamicPort();
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
 

--- a/client/integration-tests/enum-unexpected/pom.xml
+++ b/client/integration-tests/enum-unexpected/pom.xml
@@ -27,8 +27,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/integration-tests/enum-unexpected/src/test/java/io/quarkiverse/openapi/generator/it/EnumUnexpectedTest.java
+++ b/client/integration-tests/enum-unexpected/src/test/java/io/quarkiverse/openapi/generator/it/EnumUnexpectedTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -35,6 +34,8 @@ class EnumUnexpectedTest {
     @RestClient
     @Inject
     org.openapi.quarkus.with_enum_unexpected_yaml.api.DefaultApi api;
+    @Inject
+    ObjectMapper objectMapper;
 
     @Test
     void apiIsBeingGenerated() {
@@ -44,9 +45,6 @@ class EnumUnexpectedTest {
         Assertions.assertThat(echo.getMsgType())
                 .isEqualTo(org.openapi.quarkus.with_enum_unexpected_yaml.model.Echo.MsgTypeEnum.UNEXPECTED);
     }
-
-    @Inject
-    ObjectMapper objectMapper;
 
     @Test
     void when_additional_enum_type_unexpected_member_is_true_should_have_extra_member() {
@@ -89,8 +87,7 @@ class EnumUnexpectedTest {
         }
 
         private void configureWiremockServer() {
-            var wireMockConfiguration = WireMockConfiguration.wireMockConfig()
-                    .extensions(new ResponseTemplateTransformer(false)).dynamicPort();
+            var wireMockConfiguration = WireMockConfiguration.wireMockConfig().dynamicPort();
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
 

--- a/client/integration-tests/generation-tests/pom.xml
+++ b/client/integration-tests/generation-tests/pom.xml
@@ -25,8 +25,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/client/integration-tests/multipart-request/pom.xml
+++ b/client/integration-tests/multipart-request/pom.xml
@@ -21,8 +21,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/integration-tests/open-api-normalizer/pom.xml
+++ b/client/integration-tests/open-api-normalizer/pom.xml
@@ -26,8 +26,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/integration-tests/polymorphism/pom.xml
+++ b/client/integration-tests/polymorphism/pom.xml
@@ -21,8 +21,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client/integration-tests/polymorphism/src/test/java/io/quarkiverse/openapi/generator/it/PolymorphismTest.java
+++ b/client/integration-tests/polymorphism/src/test/java/io/quarkiverse/openapi/generator/it/PolymorphismTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -52,8 +51,7 @@ class PolymorphismTest {
         }
 
         private void configureWiremockServer() {
-            var wireMockConfiguration = WireMockConfiguration.wireMockConfig()
-                    .extensions(new ResponseTemplateTransformer(false)).dynamicPort();
+            var wireMockConfiguration = WireMockConfiguration.wireMockConfig().dynamicPort();
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
 

--- a/client/integration-tests/pom.xml
+++ b/client/integration-tests/pom.xml
@@ -46,9 +46,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <version>${version.com.github.tomakehurst}</version>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${version.org.wiremock}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -73,6 +73,10 @@
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-resteasy-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-multipart-provider</artifactId>
         </dependency>
       </dependencies>
       <build>

--- a/client/integration-tests/security/pom.xml
+++ b/client/integration-tests/security/pom.xml
@@ -26,8 +26,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/client/integration-tests/skip-validation/pom.xml
+++ b/client/integration-tests/skip-validation/pom.xml
@@ -22,8 +22,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/integration-tests/type-mapping/pom.xml
+++ b/client/integration-tests/type-mapping/pom.xml
@@ -21,8 +21,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/test-utils/pom.xml
+++ b/client/test-utils/pom.xml
@@ -22,8 +22,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,32 +10,7 @@
   <artifactId>quarkus-openapi-generator-parent</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Quarkus - Openapi Generator - Parent<
-  <modules>
-    <module>client</module>
-    <module>server</module>
-  </modules>
-  <scm>
-    <connection>:git:git@github.com:quarkiverse/quarkus-openapi-generator.git</connection>
-    <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-openapi-generator.git</developerConnection>
-    <url>https://github.com/quarkiverse/quarkus-openapi-generator</url>
-    <tag>HEAD</tag>
-  </scm>
-  <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>17</maven.compiler.release>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.17.2</quarkus.version>
-    <apicurio.version>1.1.1.Final</apicurio.version>
-    <version.com.github.javaparser>3.26.2</version.com.github.javaparser>
-    <version.org.assertj>3.26.3</version.org.assertj>
-    <version.org.eclipse.microprofile.fault-tolerance>4.1.1</version.org.eclipse.microprofile.fault-tolerance>
-    <version.org.wiremock>3.9.2</version.org.wiremock>
-  </properties>
-  <dependencyManagement>
-  <dependencies>
-  <dependency>/name>
+  <name>Quarkus - Openapi Generator - Parent</name>
   <modules>
     <module>client</module>
     <module>server</module>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>quarkus-openapi-generator-parent</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Quarkus - Openapi Generator - Parent</name>
+  <name>Quarkus - Openapi Generator - Parent<
   <modules>
     <module>client</module>
     <module>server</module>
@@ -31,7 +31,32 @@
     <version.com.github.javaparser>3.26.2</version.com.github.javaparser>
     <version.org.assertj>3.26.3</version.org.assertj>
     <version.org.eclipse.microprofile.fault-tolerance>4.1.1</version.org.eclipse.microprofile.fault-tolerance>
-    <version.com.github.tomakehurst>2.35.2</version.com.github.tomakehurst>
+    <version.org.wiremock>3.9.2</version.org.wiremock>
+  </properties>
+  <dependencyManagement>
+  <dependencies>
+  <dependency>/name>
+  <modules>
+    <module>client</module>
+    <module>server</module>
+  </modules>
+  <scm>
+    <connection>:git:git@github.com:quarkiverse/quarkus-openapi-generator.git</connection>
+    <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-openapi-generator.git</developerConnection>
+    <url>https://github.com/quarkiverse/quarkus-openapi-generator</url>
+    <tag>HEAD</tag>
+  </scm>
+  <properties>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <quarkus.version>3.17.2</quarkus.version>
+    <apicurio.version>1.1.1.Final</apicurio.version>
+    <version.com.github.javaparser>3.26.2</version.com.github.javaparser>
+    <version.org.assertj>3.26.3</version.org.assertj>
+    <version.org.eclipse.microprofile.fault-tolerance>4.1.1</version.org.eclipse.microprofile.fault-tolerance>
+    <version.org.wiremock>3.9.2</version.org.wiremock>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -63,9 +88,9 @@
         <version>${apicurio.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <version>${version.com.github.tomakehurst}</version>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${version.org.wiremock}</version>
       </dependency>
       <!-- Test -->
       <dependency>


### PR DESCRIPTION
In this PR:

- Upgrade WireMock to `3.9.2` and change group and artifact IDs
- Add Jboss RestEasy Multipart to the `integration-tests` module since on [Quarkus 3.15.x](https://github.com/quarkusio/quarkus/blob/3.15/extensions/resteasy-classic/resteasy-client/runtime/pom.xml), this dependency is not added to RestEasy Client.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
