### PR TITLE
Convert client and server modules to use @ConfigMapping

### DIFF
--- a/client/deployment/pom.xml
+++ b/client/deployment/pom.xml
@@ -169,9 +169,6 @@
                   <version>${quarkus.version}</version>
                 </path>
               </annotationProcessorPaths>
-              <compilerArgs>
-                <arg>-AlegacyConfigRoot=true</arg>
-              </compilerArgs>
             </configuration>
           </execution>
         </executions>

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -7,30 +7,32 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiGeneratorOutputPaths;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
 import io.smallrye.config.common.utils.StringUtil;
 
 // This configuration is read in codegen phase (before build time), the annotation is for document purposes and avoiding quarkus warns
-@ConfigRoot(name = CodegenConfig.CODEGEN_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
-public class CodegenConfig extends GlobalCodegenConfig {
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus." + CodegenConfig.CODEGEN_TIME_CONFIG_PREFIX)
+public interface CodegenConfig extends GlobalCodegenConfig {
 
-    static final String CODEGEN_TIME_CONFIG_PREFIX = "openapi-generator.codegen";
+    String CODEGEN_TIME_CONFIG_PREFIX = "openapi-generator.codegen";
 
-    public static final String API_PKG_SUFFIX = ".api";
-    public static final String MODEL_PKG_SUFFIX = ".model";
+    String API_PKG_SUFFIX = ".api";
+    String MODEL_PKG_SUFFIX = ".model";
 
-    public static final String ADDITIONAL_ENUM_TYPE_UNEXPECTED_MEMBER_NAME_DEFAULT = "UNEXPECTED";
-    public static final String ADDITIONAL_ENUM_TYPE_UNEXPECTED_MEMBER_STRING_VALUE_DEFAULT = "unexpected";
+    String ADDITIONAL_ENUM_TYPE_UNEXPECTED_MEMBER_NAME_DEFAULT = "UNEXPECTED";
+    String ADDITIONAL_ENUM_TYPE_UNEXPECTED_MEMBER_STRING_VALUE_DEFAULT = "unexpected";
     // package visibility for unit tests
-    static final String BUILD_TIME_GLOBAL_PREFIX_FORMAT = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".%s";
-    static final String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".spec.%s";
+    String BUILD_TIME_GLOBAL_PREFIX_FORMAT = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".%s";
+    String BUILD_TIME_SPEC_PREFIX_FORMAT = "quarkus." + CODEGEN_TIME_CONFIG_PREFIX + ".spec.%s";
 
-    public static final List<String> SUPPORTED_CONFIGURATIONS = Arrays.stream(ConfigName.values()).map(cn -> cn.name)
+    List<String> SUPPORTED_CONFIGURATIONS = Arrays.stream(ConfigName.values()).map(cn -> cn.name)
             .collect(Collectors.toList());
 
-    public enum ConfigName {
+    enum ConfigName {
         //global configs
         VERBOSE("verbose"),
         INPUT_BASE_DIR("input-base-dir"),
@@ -88,28 +90,28 @@ public class CodegenConfig extends GlobalCodegenConfig {
     /**
      * OpenAPI Spec details for codegen configuration.
      */
-    @ConfigItem(name = "spec")
-    public Map<String, SpecItemConfig> specItem;
+    @WithName("spec")
+    Map<String, SpecItemConfig> specItem();
 
-    public static String resolveApiPackage(final String basePackage) {
+    static String resolveApiPackage(final String basePackage) {
         return String.format("%s%s", basePackage, API_PKG_SUFFIX);
     }
 
-    public static String resolveModelPackage(final String basePackage) {
+    static String resolveModelPackage(final String basePackage) {
         return String.format("%s%s", basePackage, MODEL_PKG_SUFFIX);
     }
 
     /**
      * Return global config name, openapi-generator.codegen.config-name
      */
-    public static String getGlobalConfigName(ConfigName configName) {
+    static String getGlobalConfigName(ConfigName configName) {
         return String.format(BUILD_TIME_GLOBAL_PREFIX_FORMAT, configName.name);
     }
 
     /**
      * Return spec config name openapi-generator.codegen.spec.%s.config-name
      */
-    public static String getSpecConfigName(ConfigName configName, final Path openApiFilePath) {
+    static String getSpecConfigName(ConfigName configName, final Path openApiFilePath) {
         return String.format("%s.%s", getBuildTimeSpecPropertyPrefix(openApiFilePath), configName.name);
     }
 
@@ -119,7 +121,7 @@ public class CodegenConfig extends GlobalCodegenConfig {
      * returned value is
      * <code>openapi.generator.codegen.spec.petstore.mutiny</code>.
      */
-    public static String getSpecConfigNameByConfigKey(final String configKey, final ConfigName configName) {
+    static String getSpecConfigNameByConfigKey(final String configKey, final ConfigName configName) {
         String buildTimeSpecPropertyPrefix = String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, configKey);
         return String.format("%s.%s", buildTimeSpecPropertyPrefix, configName.name);
     }
@@ -130,11 +132,11 @@ public class CodegenConfig extends GlobalCodegenConfig {
      * `quarkus.openapi-generator."petstore_json"`.
      * Every the periods (.) in the file name will be replaced by underscore (_).
      */
-    public static String getBuildTimeSpecPropertyPrefix(final Path openApiFilePath) {
+    static String getBuildTimeSpecPropertyPrefix(final Path openApiFilePath) {
         return String.format(BUILD_TIME_SPEC_PREFIX_FORMAT, getSanitizedFileName(openApiFilePath));
     }
 
-    public static String getSanitizedFileName(final Path openApiFilePath) {
+    static String getSanitizedFileName(final Path openApiFilePath) {
         return StringUtil
                 .replaceNonAlphanumericByUnderscores(OpenApiGeneratorOutputPaths.getRelativePath(openApiFilePath).toString());
     }

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
@@ -3,8 +3,7 @@ package io.quarkiverse.openapi.generator.deployment;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithName;
 
 /*
  * Model for the configuration of this extension.
@@ -13,92 +12,91 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Not meant to be used outside this scope.
  * Config items can be applied on spec and globally as well
  */
-@ConfigGroup
-public class CommonItemConfig {
+public interface CommonItemConfig {
 
     /**
      * Whether to skip the generation of models for form parameters
      */
-    @ConfigItem(name = "skip-form-model")
-    public Optional<Boolean> skipFormModel;
+    @WithName("skip-form-model")
+    Optional<Boolean> skipFormModel();
 
     /**
      * Type Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be used for a
      * given OAS datatype (the keys of this map)
      */
-    @ConfigItem(name = "type-mappings")
-    public Map<String, String> typeMappings;
+    @WithName("type-mappings")
+    Map<String, String> typeMappings();
 
     /**
      * Import Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be
      * imported when a given OAS datatype (the keys of this map) is used
      */
-    @ConfigItem(name = "import-mappings")
-    public Map<String, String> importMappings;
+    @WithName("import-mappings")
+    Map<String, String> importMappings();
 
     /**
      * Schema Mapping is an OpenAPI Generator configuration specifying which Java types (the values) should be
      * imported when a given schema type (the keys of this map) is used
      */
-    @ConfigItem(name = "schema-mappings")
-    public Map<String, String> schemaMappings;
+    @WithName("schema-mappings")
+    Map<String, String> schemaMappings();
 
     /**
      * The specified annotations will be added to the generated model files
      */
-    @ConfigItem(name = "additional-model-type-annotations")
-    public Optional<String> additionalModelTypeAnnotations;
+    @WithName("additional-model-type-annotations")
+    Optional<String> additionalModelTypeAnnotations();
 
     /**
      * Defines if the enums should have an `UNEXPECTED` member to convey values that cannot be parsed. Default is
      * {@code false}.
      */
-    @ConfigItem(name = "additional-enum-type-unexpected-member")
-    public Optional<Boolean> additionalEnumTypeUnexpectedMemberAnnotations;
+    @WithName("additional-enum-type-unexpected-member")
+    Optional<Boolean> additionalEnumTypeUnexpectedMemberAnnotations();
 
     /**
      * The specified annotations will be added to the generated api files
      */
-    @ConfigItem(name = "additional-api-type-annotations")
-    public Optional<String> additionalApiTypeAnnotations;
+    @WithName("additional-api-type-annotations")
+    Optional<String> additionalApiTypeAnnotations();
 
     /**
      * Add custom/additional HTTP Headers or other args to every request
      */
-    @ConfigItem(name = "additional-request-args")
-    public Optional<String> additionalRequestArgs;
+    @WithName("additional-request-args")
+    Optional<String> additionalRequestArgs();
 
     /**
      * Defines if the methods should return {@link jakarta.ws.rs.core.Response} or a model. Default is {@code false}.
      */
-    @ConfigItem(name = "return-response")
-    public Optional<Boolean> returnResponse;
+    @WithName("return-response")
+    Optional<Boolean> returnResponse();
 
     /**
      * Defines if security support classes should be generated
      */
-    @ConfigItem(name = "enable-security-generation")
-    public Optional<String> enableSecurityGeneration;
+    @WithName("enable-security-generation")
+    Optional<String> enableSecurityGeneration();
 
     /**
      * Defines the normalizer options.
      */
-    @ConfigItem(name = "open-api-normalizer")
-    public Map<String, String> normalizer;
+    @WithName("open-api-normalizer")
+    Map<String, String> normalizer();
 
     /**
      * Enable SmallRye Mutiny support. If you set this to {@code true}, all return types will be wrapped in
      * {@link io.smallrye.mutiny.Uni}.
      */
-    @ConfigItem(name = "mutiny")
-    public Optional<Boolean> supportMutiny;
+    @WithName("mutiny")
+    Optional<Boolean> supportMutiny();
 
     /**
      * Defines with SmallRye Mutiny enabled if methods should return {@link jakarta.ws.rs.core.Response} or a model. Default is
      * {@code false}.
      */
-    @ConfigItem(name = "mutiny.return-response")
-    public Optional<Boolean> mutinyReturnResponse;
+    @WithName("mutiny.return-response")
+    Optional<Boolean> mutinyReturnResponse();
 
     /**
      * Handles the return type for each operation, depending on the configuration.
@@ -125,16 +123,16 @@ public class CommonItemConfig {
      * - If the operation has a void return type, it will return {@link io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>}.
      * - Otherwise, it will return {@link io.smallrye.mutiny.Uni<returnType>}`.
      */
-    @ConfigItem(name = "mutiny.operation-ids")
-    public Optional<Map<String, String>> mutinyMultiOperationIds;
+    @WithName("mutiny.operation-ids")
+    Map<String, String> mutinyMultiOperationIds();
 
     /**
      * Defines, whether the `PartFilename` ({@link org.jboss.resteasy.reactive.PartFilename} or
      * {@link org.jboss.resteasy.annotations.providers.multipart.PartFilename}) annotation should be generated for
      * MultipartForm POJOs. By setting to {@code false}, the annotation will not be generated.
      */
-    @ConfigItem(name = "generate-part-filename")
-    public Optional<Boolean> generatePartFilename;
+    @WithName("generate-part-filename")
+    Optional<Boolean> generatePartFilename();
 
     /**
      * Defines the filename for a part in case the `PartFilename` annotation
@@ -143,40 +141,40 @@ public class CommonItemConfig {
      * In case no value is set, the default one is `&lt;fieldName&gt;File` or `file`, depending on the
      * {@link CommonItemConfig#useFieldNameInPartFilename} configuration.
      */
-    @ConfigItem(name = "part-filename-value")
-    public Optional<String> partFilenameValue;
+    @WithName("part-filename-value")
+    Optional<String> partFilenameValue();
 
     /**
      * Defines, whether the filename should also include the property name in case the `PartFilename` annotation
      * ({@link org.jboss.resteasy.reactive.PartFilename} or
      * {@link org.jboss.resteasy.annotations.providers.multipart.PartFilename}) is generated.
      */
-    @ConfigItem(name = "use-field-name-in-part-filename")
-    public Optional<Boolean> useFieldNameInPartFilename;
+    @WithName("use-field-name-in-part-filename")
+    Optional<Boolean> useFieldNameInPartFilename();
 
     /**
      * Enable bean validation. If you set this to {@code true}, validation annotations are added to generated sources E.g.
      * {@code @Size}.
      */
-    @ConfigItem(name = "use-bean-validation")
-    public Optional<Boolean> useBeanValidation;
+    @WithName("use-bean-validation")
+    Optional<Boolean> useBeanValidation();
 
     /**
      * Enable the generation of APIs. If you set this to {@code false}, APIs will not be generated.
      */
-    @ConfigItem(name = "generate-apis")
-    public Optional<Boolean> generateApis;
+    @WithName("generate-apis")
+    Optional<Boolean> generateApis();
 
     /**
      * Enable the generation of models. If you set this to {@code false}, models will not be generated.
      */
-    @ConfigItem(name = "generate-models")
-    public Optional<Boolean> generateModels;
+    @WithName("generate-models")
+    Optional<Boolean> generateModels();
 
     /**
      * Enable the generation of equals and hashcode in models. If you set this to {@code false}, the models
      * will not have equals and hashcode.
      */
-    @ConfigItem(name = "equals-hashcode")
-    public Optional<Boolean> equalsHashcode;
+    @WithName("equals-hashcode")
+    Optional<Boolean> equalsHashcode();
 }

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/GlobalCodegenConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/GlobalCodegenConfig.java
@@ -2,8 +2,8 @@ package io.quarkiverse.openapi.generator.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /*
  * Model for the configuration of this extension.
@@ -12,50 +12,51 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Not meant to be used outside this scope.
  * Config items can be applied only globally
  */
-@ConfigGroup
-public class GlobalCodegenConfig extends CommonItemConfig {
+public interface GlobalCodegenConfig extends CommonItemConfig {
 
     /**
      * Whether to log the internal generator codegen process in the default output or not.
      */
-    @ConfigItem(name = "verbose", defaultValue = "false")
-    public boolean verbose;
+    @WithDefault("false")
+    @WithName("verbose")
+    boolean verbose();
 
     /**
      * Option to change the directory where OpenAPI files must be found.
      */
-    @ConfigItem(name = "input-base-dir")
-    public Optional<String> inputBaseDir;
+    @WithName("input-base-dir")
+    Optional<String> inputBaseDir();
 
     /**
      * Option to change the directory where template files must be found.
      */
-    @ConfigItem(name = "template-base-dir")
-    public Optional<String> templateBaseDir;
+    @WithName("template-base-dir")
+    Optional<String> templateBaseDir();
 
     /**
      * Whether or not to skip validating the input spec prior to generation. By default, invalid specifications will result in
      * an error.
      */
-    @ConfigItem(name = "validateSpec", defaultValue = "true")
-    public boolean validateSpec;
+    @WithName("validateSpec")
+    @WithDefault("true")
+    boolean validateSpec();
 
     /**
      * Option to specify files for which generation should be executed only
      */
-    @ConfigItem(name = "include")
-    public Optional<String> include;
+    @WithName("include")
+    Optional<String> include();
 
     /**
      * Option to exclude file from generation
      */
-    @ConfigItem(name = "exclude")
-    public Optional<String> exclude;
+    @WithName("exclude")
+    Optional<String> exclude();
 
     /**
      * Create security for the referenced security scheme
      */
-    @ConfigItem(name = "default-security-scheme")
-    public Optional<String> defaultSecuritySchema;
+    @WithName("default-security-scheme")
+    Optional<String> defaultSecuritySchema();
 
 }

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/SpecItemConfig.java
@@ -2,8 +2,7 @@ package io.quarkiverse.openapi.generator.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithName;
 
 /*
  * Model for the configuration of this extension.
@@ -12,48 +11,48 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * Not meant to be used outside this scope.
  * Config items can be applied only on spec
  */
-@ConfigGroup
-public class SpecItemConfig extends CommonItemConfig {
+public interface SpecItemConfig extends CommonItemConfig {
 
     /**
      * Base package for where the generated code for the given OpenAPI specification will be added.
      */
-    @ConfigItem(name = "base-package")
-    public Optional<String> basePackage;
+    @WithName("base-package")
+    Optional<String> basePackage();
 
     /**
      * Suffix name for generated api classes
      */
-    @ConfigItem(name = "api-name-suffix")
-    public Optional<String> apiNameSuffix;
+    @WithName("api-name-suffix")
+    Optional<String> apiNameSuffix();
 
     /**
      * Suffix name for generated model classes
      */
-    @ConfigItem(name = "model-name-suffix")
-    public Optional<String> modelNameSuffix;
+    @WithName("model-name-suffix")
+    Optional<String> modelNameSuffix();
 
     /**
      * Prefix name for generated model classes
      */
-    @ConfigItem(name = "model-name-prefix")
-    public Optional<String> modelNamePrefix;
+    @WithName("model-name-prefix")
+    Optional<String> modelNamePrefix();
 
     /**
      * Remove operation id prefix
      */
-    @ConfigItem(name = "remove-operation-id-prefix")
-    public Optional<Boolean> removeOperationIdPrefix;
+
+    @WithName("remove-operation-id-prefix")
+    Optional<Boolean> removeOperationIdPrefix();
 
     /**
      * Remove operation id prefix
      */
-    @ConfigItem(name = "remove-operation-id-prefix-delimiter")
-    public Optional<String> removeOperationIdPrefixDelimiter;
+    @WithName("remove-operation-id-prefix-delimiter")
+    Optional<String> removeOperationIdPrefixDelimiter();
 
     /**
      * Remove operation id prefix
      */
-    @ConfigItem(name = "remove-operation-id-prefix-count")
-    public Optional<Integer> removeOperationIdPrefixCount;
+    @WithName("remove-operation-id-prefix-count")
+    Optional<Integer> removeOperationIdPrefixCount();
 }

--- a/client/runtime/pom.xml
+++ b/client/runtime/pom.xml
@@ -94,9 +94,6 @@
                   <version>${quarkus.version}</version>
                 </path>
               </annotationProcessorPaths>
-              <compilerArgs>
-                <arg>-AlegacyConfigRoot=true</arg>
-              </compilerArgs>
             </configuration>
           </execution>
         </executions>

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/AuthsConfig.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/AuthsConfig.java
@@ -3,11 +3,9 @@ package io.quarkiverse.openapi.generator;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithParentName;
 
-@ConfigGroup
-public class AuthsConfig {
+public interface AuthsConfig {
 
     /**
      * Configurations for the individual securitySchemes present on a given OpenApi spec definition file.
@@ -21,17 +19,10 @@ public class AuthsConfig {
      * @see SpecItemConfig
      * @see AuthConfig
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, AuthConfig> authConfigs;
+    @WithParentName()
+    Map<String, AuthConfig> authConfigs();
 
-    public Optional<AuthConfig> getItemConfig(String authConfig) {
-        return Optional.ofNullable(authConfigs.get(authConfig));
-    }
-
-    @Override
-    public String toString() {
-        return "AuthsConfig{" +
-                "authConfigs=" + authConfigs +
-                '}';
+    default Optional<AuthConfig> getItemConfig(String authConfig) {
+        return Optional.ofNullable(authConfigs().get(authConfig));
     }
 }

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/OpenApiGeneratorConfig.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/OpenApiGeneratorConfig.java
@@ -3,18 +3,20 @@ package io.quarkiverse.openapi.generator;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 import io.smallrye.config.common.utils.StringUtil;
 
 /**
  * This class represents the runtime configurations for the openapi-generator extension.
  */
-@ConfigRoot(name = OpenApiGeneratorConfig.RUNTIME_TIME_CONFIG_PREFIX, phase = ConfigPhase.RUN_TIME)
-public class OpenApiGeneratorConfig {
+@ConfigMapping(prefix = "quarkus." + OpenApiGeneratorConfig.RUNTIME_TIME_CONFIG_PREFIX)
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface OpenApiGeneratorConfig {
 
-    public static final String RUNTIME_TIME_CONFIG_PREFIX = "openapi-generator";
+    String RUNTIME_TIME_CONFIG_PREFIX = "openapi-generator";
 
     /**
      * Configurations of the individual OpenApi spec definitions, i.e. the provided files.
@@ -23,21 +25,14 @@ public class OpenApiGeneratorConfig {
      * For example, a file named petstore.json is sanitized into the name petstore_json, and thus the specific
      * configurations this file must start with the prefix quarkus.openapi-generator.petstore_json
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, SpecItemConfig> itemConfigs;
+    @WithParentName
+    Map<String, SpecItemConfig> itemConfigs();
 
-    public Optional<SpecItemConfig> getItemConfig(String specItem) {
-        return Optional.ofNullable(itemConfigs.get(specItem));
+    default Optional<SpecItemConfig> getItemConfig(String specItem) {
+        return Optional.ofNullable(itemConfigs().get(specItem));
     }
 
-    @Override
-    public String toString() {
-        return "OpenApiGeneratorConfig{" +
-                "itemConfigs=" + itemConfigs +
-                '}';
-    }
-
-    public static String getSanitizedSecuritySchemeName(final String securitySchemeName) {
+    static String getSanitizedSecuritySchemeName(final String securitySchemeName) {
         return StringUtil.replaceNonAlphanumericByUnderscores(securitySchemeName);
     }
 }

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
@@ -2,15 +2,11 @@ package io.quarkiverse.openapi.generator;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
-
 /**
  * This class represents the runtime authentication related configurations for the individual OpenApi spec definitions,
  * i.e. the provided files.
  */
-@ConfigGroup
-public class SpecItemConfig {
+public interface SpecItemConfig {
 
     /**
      * Authentication related configurations for the different securitySchemes present on a given OpenApi spec
@@ -21,17 +17,9 @@ public class SpecItemConfig {
      *
      * @see AuthsConfig
      */
-    @ConfigItem
-    public AuthsConfig auth;
+    AuthsConfig auth();
 
-    public Optional<AuthsConfig> getAuth() {
-        return Optional.ofNullable(auth);
-    }
-
-    @Override
-    public String toString() {
-        return "SpecItemConfig{" +
-                "auth=" + auth +
-                '}';
+    default Optional<AuthsConfig> getAuth() {
+        return Optional.ofNullable(auth());
     }
 }

--- a/server/deployment/pom.xml
+++ b/server/deployment/pom.xml
@@ -38,9 +38,6 @@
                                     <version>${quarkus.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>

--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/CodegenConfig.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/CodegenConfig.java
@@ -2,29 +2,31 @@ package io.quarkiverse.openapi.server.generator.deployment;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigRoot(name = CodegenConfig.CODEGEN_TIME_CONFIG_PREFIX, phase = ConfigPhase.BUILD_TIME)
-public class CodegenConfig {
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = CodegenConfig.CODEGEN_TIME_CONFIG_PREFIX)
+public interface CodegenConfig {
 
-    static final String CODEGEN_TIME_CONFIG_PREFIX = "quarkus.openapi.generator";
-    private static final String CODEGEN_BASE_PACKAGE = CODEGEN_TIME_CONFIG_PREFIX + ".base-package";
-    private static final String CODEGEN_SPEC = CODEGEN_TIME_CONFIG_PREFIX + ".spec";
-    private static final String INPUT_BASE_DIR = CODEGEN_TIME_CONFIG_PREFIX + ".input-base-dir";
-    private static final String CODEGEN_REACTIVE = CODEGEN_TIME_CONFIG_PREFIX + ".reactive";
+    String CODEGEN_TIME_CONFIG_PREFIX = "quarkus.openapi.generator";
+    String CODEGEN_BASE_PACKAGE = CODEGEN_TIME_CONFIG_PREFIX + ".base-package";
+    String CODEGEN_SPEC = CODEGEN_TIME_CONFIG_PREFIX + ".spec";
+    String INPUT_BASE_DIR = CODEGEN_TIME_CONFIG_PREFIX + ".input-base-dir";
+    String CODEGEN_REACTIVE = CODEGEN_TIME_CONFIG_PREFIX + ".reactive";
 
-    public static String getBasePackagePropertyName() {
+    static String getBasePackagePropertyName() {
         return CODEGEN_BASE_PACKAGE;
     }
 
-    public static String getSpecPropertyName() {
+    static String getSpecPropertyName() {
         return CODEGEN_SPEC;
     }
 
-    public static String getInputBaseDirPropertyName() {
+    static String getInputBaseDirPropertyName() {
         return INPUT_BASE_DIR;
     }
 
-    public static String getCodegenReactive() {
+    static String getCodegenReactive() {
         return CODEGEN_REACTIVE;
     }
 }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Fixes #https://github.com/quarkiverse/quarkus-openapi-generator/issues/793

This pull request convert the extension to use the new way to configure a extension. This pull request follows the migration guide, removing the need to use the following option:

```xml
<compilerArgs><arg>-AlegacyConfigRoot=true</arg>
```

Additionaly, I change the security configuration to be RUNTIME phase.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
