### PR TITLE
[issues#959] Fix `api.qute` condition to include the `baseUri` to `@RegisterRestClient`

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/api.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/api.qute
@@ -18,7 +18,7 @@ import {imp.import};
   */
 {/if}
 @jakarta.ws.rs.Path("{#if useAnnotatedBasePath.or(false)}{contextPath}{/if}{commonPath}")
-@org.eclipse.microprofile.rest.client.inject.RegisterRestClient({#if !defaultServerUrl.or('') == ''}baseUri="{defaultServerUrl}", {/if}configKey="{configKey}")
+@org.eclipse.microprofile.rest.client.inject.RegisterRestClient({#if defaultServerUrl.or('') != ''}baseUri="{defaultServerUrl}", {/if}configKey="{configKey}")
 @io.quarkiverse.openapi.generator.annotations.GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if enable-security-generation && openapi:hasAuthMethods(operations) }
 @org.eclipse.microprofile.rest.client.annotation.RegisterProvider({package}.auth.CompositeAuthenticationProvider.class)

--- a/client/integration-tests/change-custom-template-directory/src/main/custom/templates/api.qute
+++ b/client/integration-tests/change-custom-template-directory/src/main/custom/templates/api.qute
@@ -35,7 +35,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
   */
 {/if}
 @Path("{commonPath}")
-@RegisterRestClient({#if !defaultServerUrl.or('') == ''}baseUri="{defaultServerUrl}",{/if} configKey="{configKey}")
+@RegisterRestClient({#if defaultServerUrl.or('') != ''}baseUri="{defaultServerUrl}",{/if} configKey="{configKey}")
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if openapi:hasAuthMethods(operations)}
 @RegisterProvider(CompositeAuthenticationProvider.class)

--- a/client/integration-tests/custom-templates/src/main/resources/templates/api.qute
+++ b/client/integration-tests/custom-templates/src/main/resources/templates/api.qute
@@ -35,7 +35,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
   */
 {/if}
 @Path("{commonPath}")
-@RegisterRestClient({#if !defaultServerUrl.or('') == ''}baseUri="{defaultServerUrl}", {/if}configKey="{configKey}")
+@RegisterRestClient({#if defaultServerUrl.or('') != ''}baseUri="{defaultServerUrl}", {/if}configKey="{configKey}")
 @GeneratedClass(value="{openapi:parseUri(inputSpec)}", tag = "{baseName}")
 {#if openapi:hasAuthMethods(operations)}
 @RegisterProvider(CompositeAuthenticationProvider.class)


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/959

This PR fixes a condition in the `api.qute` template that was making the generated Api.java not include the `baseUri` even if it was present in openapi spec file.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ ] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
