### PR TITLE
[issues#964] Fix beanValidationCore.qute condition to include the jakarta.validation.Valid annotation

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/beanValidationCore.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/beanValidationCore.qute
@@ -34,3 +34,6 @@
     @jakarta.validation.constraints.DecimalMax("{p.maximum}")
     {/if}
     {/if}
+    {#if use-bean-validation}
+    @jakarta.validation.Valid
+    {/if}

--- a/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
+++ b/client/integration-tests/bean-validation/src/test/java/io/quarkiverse/openapi/generator/it/BeanValidationTest.java
@@ -63,6 +63,7 @@ class BeanValidationTest {
         assertThat(name.getAnnotationsByType(Size.class)).hasSize(2);
         assertThat(name.getAnnotationsByType(Size.class)[0].min()).isEqualTo(1);
         assertThat(name.getAnnotationsByType(Size.class)[1].max()).isEqualTo(10);
+        assertThat(name.isAnnotationPresent(Valid.class)).isTrue();
 
         assertThat(size.isAnnotationPresent(DecimalMin.class)).isTrue();
         assertThat(size.getAnnotation(DecimalMin.class).value()).isEqualTo("1.0");
@@ -94,6 +95,7 @@ class BeanValidationTest {
         assertThat(id.isAnnotationPresent(Max.class)).isFalse();
         assertThat(name.isAnnotationPresent(Pattern.class)).isFalse();
         assertThat(name.isAnnotationPresent(Size.List.class)).isFalse();
+        assertThat(name.isAnnotationPresent(Valid.class)).isFalse();
         assertThat(size.isAnnotationPresent(DecimalMin.class)).isFalse();
         assertThat(size.isAnnotationPresent(DecimalMax.class)).isFalse();
     }


### PR DESCRIPTION
Fixed #964 

This PR fixes a condition in the `beanValidationCore.qute` template that was making the generated model classes fields not include the jakarta.validation.Valid annotation when `use-bean-validation` was `true`.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
