### PR TITLE
Drop legacyConfigRoot as it is not necessary

### DIFF
--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -55,9 +55,6 @@
                                     <version>${quarkus.version}</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <compilerArgs>
-                                <arg>-AlegacyConfigRoot=true</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
(I'm currently going through the Quarkiverse extensions using legacy config roots).