### PR TITLE
Fix #1038 - Do not register duplicated AuthProviders SyntheticBeans

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
@@ -23,7 +23,7 @@ public class CompositeAuthenticationProvider implements jakarta.ws.rs.client.Cli
 
     @jakarta.inject.Inject
     @io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{quarkus-generator.openApiSpecId}")
-    io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider compositeProvider;
+    io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider compositeProvider;
 
     @java.lang.Override
     public void filter(jakarta.ws.rs.client.ClientRequestContext context) throws java.io.IOException {

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/auth/headersFactory.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/auth/headersFactory.qute
@@ -3,7 +3,7 @@ package {apiPackage}.auth;
 public class AuthenticationPropagationHeadersFactory extends io.quarkiverse.openapi.generator.providers.AbstractAuthenticationPropagationHeadersFactory {
 
     @jakarta.inject.Inject
-    public AuthenticationPropagationHeadersFactory(@io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{quarkus-generator.openApiSpecId}") io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider compositeProvider, io.quarkiverse.openapi.generator.OpenApiGeneratorConfig generatorConfig, io.quarkiverse.openapi.generator.providers.HeadersProvider headersProvider) {
+    public AuthenticationPropagationHeadersFactory(@io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="{quarkus-generator.openApiSpecId}") io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider compositeProvider, io.quarkiverse.openapi.generator.OpenApiGeneratorConfig generatorConfig, io.quarkiverse.openapi.generator.providers.HeadersProvider headersProvider) {
         super(compositeProvider, generatorConfig, headersProvider);
     }
 

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/authentication/OpenApiSpecProviderTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/authentication/OpenApiSpecProviderTest.java
@@ -20,8 +20,8 @@ import io.quarkiverse.openapi.generator.markers.OauthAuthenticationMarker;
 import io.quarkiverse.openapi.generator.oidc.providers.OAuth2AuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.ApiKeyAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.AuthProvider;
+import io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.BasicAuthenticationProvider;
-import io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class OpenApiSpecProviderTest {
@@ -41,19 +41,19 @@ public class OpenApiSpecProviderTest {
 
     @Inject
     @OpenApiSpec(openApiSpecId = "spec_1")
-    CompositeAuthenticationProvider spec1CompositeProvider;
+    BaseCompositeAuthenticationProvider spec1CompositeProvider;
 
     @Inject
     @OpenApiSpec(openApiSpecId = "spec_2")
-    CompositeAuthenticationProvider spec2CompositeProvider;
+    BaseCompositeAuthenticationProvider spec2CompositeProvider;
 
     @Inject
     @OpenApiSpec(openApiSpecId = "spec_3")
-    CompositeAuthenticationProvider spec3CompositeProvider;
+    BaseCompositeAuthenticationProvider spec3CompositeProvider;
 
     @Inject
     @OpenApiSpec(openApiSpecId = "spec_multi")
-    CompositeAuthenticationProvider multiCompositeProvider;
+    BaseCompositeAuthenticationProvider multiCompositeProvider;
 
     @Test
     public void checkCompositeProvider() {

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/authentication/OperationTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/authentication/OperationTest.java
@@ -20,7 +20,7 @@ import io.quarkiverse.openapi.generator.annotations.GeneratedClass;
 import io.quarkiverse.openapi.generator.markers.BasicAuthenticationMarker;
 import io.quarkiverse.openapi.generator.markers.OauthAuthenticationMarker;
 import io.quarkiverse.openapi.generator.markers.OperationMarker;
-import io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider;
+import io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -40,10 +40,10 @@ public class OperationTest {
 
     @Inject
     @OpenApiSpec(openApiSpecId = "petstore_json")
-    CompositeAuthenticationProvider compositeProvider;
+    BaseCompositeAuthenticationProvider compositeProvider;
     @Inject
     @OpenApiSpec(openApiSpecId = "other_spec_json")
-    CompositeAuthenticationProvider otherProvider;
+    BaseCompositeAuthenticationProvider otherProvider;
 
     @Test
     public void test() {

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/AuthenticationRecorder.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/AuthenticationRecorder.java
@@ -10,9 +10,9 @@ import io.quarkiverse.openapi.generator.OpenApiSpec.Literal;
 import io.quarkiverse.openapi.generator.providers.ApiKeyAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.ApiKeyIn;
 import io.quarkiverse.openapi.generator.providers.AuthProvider;
+import io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.BasicAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.BearerAuthenticationProvider;
-import io.quarkiverse.openapi.generator.providers.CompositeAuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -20,12 +20,12 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class AuthenticationRecorder {
 
-    public Function<SyntheticCreationalContext<CompositeAuthenticationProvider>, CompositeAuthenticationProvider> recordCompositeProvider(
+    public Function<SyntheticCreationalContext<BaseCompositeAuthenticationProvider>, BaseCompositeAuthenticationProvider> recordCompositeProvider(
             String openApiSpec) {
         return ctx -> {
             List<AuthProvider> providers = ctx.getInjectedReference(new TypeLiteral<Instance<AuthProvider>>() {
             }, new Literal(openApiSpec)).stream().toList();
-            return new CompositeAuthenticationProvider(providers);
+            return new BaseCompositeAuthenticationProvider(providers);
         };
     }
 

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthenticationPropagationHeadersFactory.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/AbstractAuthenticationPropagationHeadersFactory.java
@@ -19,11 +19,11 @@ public abstract class AbstractAuthenticationPropagationHeadersFactory implements
     private static final String HEADER_NAME_PREFIX_FOR_TOKEN_PROPAGATION = "QCG_%s";
     private static final String HEADER_NAME_FOR_TOKEN_PROPAGATION = "QCG_%s_%s_%s";
 
-    protected CompositeAuthenticationProvider compositeProvider;
+    protected BaseCompositeAuthenticationProvider compositeProvider;
     protected OpenApiGeneratorConfig generatorConfig;
     protected HeadersProvider headersProvider;
 
-    protected AbstractAuthenticationPropagationHeadersFactory(CompositeAuthenticationProvider compositeProvider,
+    protected AbstractAuthenticationPropagationHeadersFactory(BaseCompositeAuthenticationProvider compositeProvider,
             OpenApiGeneratorConfig generatorConfig,
             HeadersProvider headersProvider) {
         this.compositeProvider = compositeProvider;

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
@@ -16,11 +16,11 @@ import io.quarkiverse.openapi.generator.OpenApiGeneratorConfig;
  * Composition of supported {@link ClientRequestFilter} defined by a given OpenAPI interface.
  * This class is used as the base class of generated code.
  */
-public class CompositeAuthenticationProvider implements ClientRequestFilter {
+public class BaseCompositeAuthenticationProvider implements ClientRequestFilter {
 
     private final List<AuthProvider> authProviders;
 
-    public CompositeAuthenticationProvider(List<AuthProvider> authProviders) {
+    public BaseCompositeAuthenticationProvider(List<AuthProvider> authProviders) {
         this.authProviders = List.copyOf(authProviders);
     }
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Fixes #1038 

Somehow Jandex is returning duplicated `*AuthenticationMarkers` annotations from the generated `CompositeAuthenticationProvider` classes:

```java
package org.eurotransplant.immu.api.auth;

@jakarta.annotation.Priority(jakarta.ws.rs.Priorities.AUTHENTICATION)
@io.quarkiverse.openapi.generator.markers.BearerAuthenticationMarker(name="SecurityScheme", openApiSpecId="immu_2024_04_29_yml", scheme="bearer")
public class CompositeAuthenticationProvider implements jakarta.ws.rs.client.ClientRequestFilter {

    @jakarta.inject.Inject
    @io.quarkiverse.openapi.generator.OpenApiSpec(openApiSpecId="immu_2024_04_29_yml")
    io.quarkiverse.openapi.generator.providers.BaseCompositeAuthenticationProvider compositeProvider;

    @java.lang.Override
    public void filter(jakarta.ws.rs.client.ClientRequestContext context) throws java.io.IOException {
        compositeProvider.filter(context);
    };
}
```

In the reproducer provided in #1038, the class is being generated correctly, but during the build process, Jandex is returning duplicate annotations.

I ran out of time to debug more, so now the lists are being filtered to return only once, despite Jandex holding two instances of the same annotation.

@pefernan @fjtirado, this is a critical bug that should be fixed in Kogito by upgrading this library once we release a patch with this fix.

I've changed the name of our `CompositeAuthenticationProvider` to `BaseCompositeAuthenticationProvider` so as not to be confused with the generated `CompositeAuthenticationProvider` in the target project.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
