### PR TITLE
Improve shouldRun method on Server extension

### DIFF
--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/ServerCodegenConfig.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/ServerCodegenConfig.java
@@ -7,6 +7,7 @@ import io.smallrye.config.WithDefault;
 public interface ServerCodegenConfig {
 
     String DEFAULT_PACKAGE = "io.apicurio.api";
+    String DEFAULT_DIR = "openapi";
 
     /**
      * The OpenAPI specification filename.


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Improve the shouldRun method for avoiding calling `trigger` method when the `inputDir` provided by `CodeGenContext` is not able to get the specification files.

Closes #1118 


Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ ] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
