### PR TITLE
Fix logger initialization class reference

### DIFF
--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/ApicurioOpenApiServerCodegen.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/ApicurioOpenApiServerCodegen.java
@@ -22,7 +22,7 @@ import io.quarkus.deployment.CodeGenProvider;
 
 public class ApicurioOpenApiServerCodegen implements CodeGenProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(ApicurioCodegenWrapper.class);
+    private static final Logger log = LoggerFactory.getLogger(ApicurioOpenApiServerCodegen.class);
 
     @Override
     public String providerId() {


### PR DESCRIPTION
Update the logger to reference `ApicurioOpenApiServerCodegen` instead of `ApicurioCodegenWrapper`. This ensures the correct class is logged, improving clarity and debugging accuracy.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
