### PR TITLE
Fix #1156 - Move AuthProviders SyntheticBean generation to Runtime

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/GeneratorProcessor.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/GeneratorProcessor.java
@@ -84,8 +84,7 @@ public class GeneratorProcessor {
     }
 
     @BuildStep
-    void additionalBean(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> producer) {
-
+    void registerOidcClientBean(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> producer) {
         if (!isClassPresentAtRuntime(ABSTRACT_TOKEN_PRODUCER)) {
             LOGGER.debug("{} class not found in runtime, skipping OidcClientRequestFilterDelegate bean generation",
                     ABSTRACT_TOKEN_PRODUCER);
@@ -101,7 +100,6 @@ public class GeneratorProcessor {
             producer.produce(AdditionalBeanBuildItem.builder().addBeanClass(ClassicOidcClientRequestFilterDelegate.class)
                     .setDefaultScope(DotName.createSimple(Dependent.class)).setUnremovable().build());
         }
-
     }
 
     @BuildStep
@@ -126,7 +124,7 @@ public class GeneratorProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void produceOauthAuthentication(CombinedIndexBuildItem beanArchiveBuildItem,
             BuildProducer<AuthProviderBuildItem> authenticationProviders,
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
@@ -178,14 +176,16 @@ public class GeneratorProcessor {
                     .done()
                     .addInjectionPoint(ClassType.create(OAuth2AuthenticationProvider.OidcClientRequestFilterDelegate.class),
                             AnnotationInstance.builder(OidcClient.class).add("name", sanitizeAuthName(name)).build())
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(CredentialsProvider.class)))
                     .createWith(oidcRecorder.recordOauthAuthProvider(sanitizeAuthName(name), openApiSpecId, operations))
+                    .setRuntimeInit()
                     .unremovable()
                     .done());
         }
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void produceBasicAuthentication(CombinedIndexBuildItem beanArchiveBuildItem,
             BuildProducer<AuthProviderBuildItem> authenticationProviders, BuildProducer<SyntheticBeanBuildItem> beanProducer,
             AuthenticationRecorder recorder) {
@@ -218,13 +218,14 @@ public class GeneratorProcessor {
                     .done()
                     .addInjectionPoint(ClassType.create(DotName.createSimple(CredentialsProvider.class)))
                     .createWith(recorder.recordBasicAuthProvider(sanitizeAuthName(name), openApiSpecId, operations))
+                    .setRuntimeInit()
                     .unremovable()
                     .done());
         }
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void produceBearerAuthentication(CombinedIndexBuildItem beanArchiveBuildItem,
             BuildProducer<AuthProviderBuildItem> authenticationProviders, BuildProducer<SyntheticBeanBuildItem> beanProducer,
             AuthenticationRecorder recorder) {
@@ -258,6 +259,7 @@ public class GeneratorProcessor {
                     .done()
                     .addInjectionPoint(ClassType.create(DotName.createSimple(CredentialsProvider.class)))
                     .createWith(recorder.recordBearerAuthProvider(sanitizeAuthName(name), scheme, openApiSpecId, operations))
+                    .setRuntimeInit()
                     .unremovable()
                     .done());
 
@@ -265,7 +267,7 @@ public class GeneratorProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void produceApiKeyAuthentication(CombinedIndexBuildItem beanArchiveBuildItem,
             BuildProducer<AuthProviderBuildItem> authenticationProviders, BuildProducer<SyntheticBeanBuildItem> beanProducer,
             AuthenticationRecorder recorder) {
@@ -302,6 +304,7 @@ public class GeneratorProcessor {
                     .addInjectionPoint(ClassType.create(DotName.createSimple(CredentialsProvider.class)))
                     .createWith(recorder.recordApiKeyAuthProvider(sanitizeAuthName(name), openApiSpecId, apiKeyIn, apiKeyName,
                             operations))
+                    .setRuntimeInit()
                     .unremovable()
                     .done());
         }

--- a/client/integration-tests/override-credential-provider/pom.xml
+++ b/client/integration-tests/override-credential-provider/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-openapi-generator-integration-tests</artifactId>
+        <groupId>io.quarkiverse.openapi.generator</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-openapi-generatir-it-override-credential-provider</artifactId>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Override Credentials Provider</name>
+    <description>Integration Test to verify https://github.com/quarkiverse/quarkus-openapi-generator/issues/1156</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.openapi.generator</groupId>
+            <artifactId>quarkus-openapi-generator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
+++ b/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.openapi.generator.it.creds;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.ws.rs.client.ClientRequestContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkiverse.openapi.generator.providers.ConfigCredentialsProvider;
+
+@Dependent
+@Alternative
+@Priority(200)
+public class CustomCredentialsProvider extends ConfigCredentialsProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomCredentialsProvider.class);
+
+    public static String TOKEN = "FIXED_TEST_TOKEN";
+
+    @Override
+    public String getBearerToken(ClientRequestContext requestContext, String openApiSpecId, String authName) {
+        LOGGER.info("========> getBearerToken");
+        return TOKEN;
+    }
+}

--- a/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
+++ b/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
@@ -20,7 +20,7 @@ public class CustomCredentialsProvider extends ConfigCredentialsProvider {
 
     @Override
     public String getBearerToken(ClientRequestContext requestContext, String openApiSpecId, String authName) {
-        LOGGER.info("========> getBearerToken");
+        LOGGER.info("========> getBearerToken from CustomCredentialsProvider");
         return TOKEN;
     }
 }

--- a/client/integration-tests/override-credential-provider/src/main/openapi/simple-server.yaml
+++ b/client/integration-tests/override-credential-provider/src/main/openapi/simple-server.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Simple server API
+  description: |-
+    Simple server API
+  version: 1.0.0
+tags:
+  - name: Simple server API
+    description: Simple server API
+servers:
+  - url: /
+paths:
+  /simple:
+    get:
+      summary: Send requests to simple server with simple JWT security scheme
+      description: Send requests to simple server to check the auth header
+      operationId: getWithSimpleBearerTokenSecurityScheme
+      responses:
+        "200":
+          description: Successful operation
+      security:
+        - SimpleBearerToken: []
+components:
+  securitySchemes:
+    SimpleBearerToken:
+      type: http
+      scheme: bearer

--- a/client/integration-tests/override-credential-provider/src/main/resources/application.properties
+++ b/client/integration-tests/override-credential-provider/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.openapi-generator.simple_server_yaml.auth.SimpleBearerToken.header-name=X-Authorization-Simple
+# We have a custom CredentialsProvider that will ignore this token set in the config and will return a hard-coded one.
+quarkus.openapi-generator.simple_server_yaml.auth.SimpleBearerToken.bearer-token=WILL_BE_OVERRIDED

--- a/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderTest.java
+++ b/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.openapi.generator.it.creds;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.openapi.quarkus.simple_server_yaml.api.DefaultApi;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@WithTestResource(SimpleServerMockResource.class)
+@QuarkusTest
+public class CustomCredentialsProviderTest {
+
+    /**
+     * @see SimpleServerMockResource#inject(QuarkusTestResourceLifecycleManager.TestInjector)
+     */
+    WireMockServer simpleServer;
+
+    @RestClient
+    @Inject
+    DefaultApi defaultApi;
+
+    /**
+     * This test validates whether the custom CredentialsProvider is override.
+     */
+    @Test
+    public void testGetHardCodedToken() {
+        Assertions.assertThat(defaultApi.getWithSimpleBearerTokenSecurityScheme().getStatus()).isEqualTo(200);
+
+        simpleServer.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/simple")).withHeader("Authorization",
+                WireMock.equalTo("Bearer " + CustomCredentialsProvider.TOKEN)));
+    }
+
+}

--- a/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderTest.java
+++ b/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderTest.java
@@ -28,7 +28,7 @@ public class CustomCredentialsProviderTest {
     DefaultApi defaultApi;
 
     /**
-     * This test validates whether the custom CredentialsProvider is override.
+     * This test validates whether the custom CredentialsProvider is overriden.
      */
     @Test
     public void testGetHardCodedToken() {

--- a/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/SimpleServerMockResource.java
+++ b/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/SimpleServerMockResource.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.openapi.generator.it.creds;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class SimpleServerMockResource implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        wireMockServer.stubFor(get(urlMatching("/simple"))
+                .willReturn(ok()));
+
+        return Collections.singletonMap("quarkus.rest-client.simple_server_yaml.url",
+                wireMockServer.baseUrl());
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer, f -> f.getName().equals("simpleServer"));
+    }
+
+    @Override
+    public void stop() {
+        if (null != wireMockServer) {
+            wireMockServer.stop();
+        }
+    }
+}

--- a/client/integration-tests/pom.xml
+++ b/client/integration-tests/pom.xml
@@ -47,6 +47,7 @@
     <module>without-oidc</module>
     <module>serializable-model</module>
     <module>equals-hashcode</module>
+    <module>override-credential-provider</module>
   </modules>
   <dependencyManagement>
     <dependencies>

--- a/client/oidc/src/main/java/io/quarkiverse/openapi/generator/oidc/OidcAuthenticationRecorder.java
+++ b/client/oidc/src/main/java/io/quarkiverse/openapi/generator/oidc/OidcAuthenticationRecorder.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import io.quarkiverse.openapi.generator.OidcClient;
 import io.quarkiverse.openapi.generator.oidc.providers.OAuth2AuthenticationProvider;
 import io.quarkiverse.openapi.generator.providers.AuthProvider;
+import io.quarkiverse.openapi.generator.providers.CredentialsProvider;
 import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -20,6 +21,7 @@ public class OidcAuthenticationRecorder {
         return context -> new OAuth2AuthenticationProvider(name, openApiSpecId,
                 context.getInjectedReference(OAuth2AuthenticationProvider.OidcClientRequestFilterDelegate.class,
                         new OidcClient.Literal(name)),
-                operations);
+                operations,
+                context.getInjectedReference(CredentialsProvider.class));
     }
 }

--- a/client/oidc/src/main/java/io/quarkiverse/openapi/generator/oidc/providers/OAuth2AuthenticationProvider.java
+++ b/client/oidc/src/main/java/io/quarkiverse/openapi/generator/oidc/providers/OAuth2AuthenticationProvider.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.openapi.generator.providers.AbstractAuthProvider;
-import io.quarkiverse.openapi.generator.providers.ConfigCredentialsProvider;
+import io.quarkiverse.openapi.generator.providers.CredentialsProvider;
 import io.quarkiverse.openapi.generator.providers.OperationAuthInfo;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 
@@ -23,8 +23,9 @@ public class OAuth2AuthenticationProvider extends AbstractAuthProvider {
     private final OidcClientRequestFilterDelegate delegate;
 
     public OAuth2AuthenticationProvider(String name,
-            String openApiSpecId, OidcClientRequestFilterDelegate delegate, List<OperationAuthInfo> operations) {
-        super(name, openApiSpecId, operations, new ConfigCredentialsProvider());
+            String openApiSpecId, OidcClientRequestFilterDelegate delegate, List<OperationAuthInfo> operations,
+            CredentialsProvider credentialsProvider) {
+        super(name, openApiSpecId, operations, credentialsProvider);
         this.delegate = delegate;
         validateConfig();
     }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Fix #1156.

Additionally, now OAuth2 provider also has an injected CredentialsProvider.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
