### PR TITLE
Fixes an issue where the generated REST client was missing a comma

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/api.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/api.qute
@@ -124,9 +124,10 @@ public interface {classname} {
             {/if}
         {/if}
         {#if additionalRequestArgs}
-            {#for arg in additionalRequestArgs}{!
-                !}{arg}{#if arg_hasNext}, {/if}{/for}{!
-            !}{#if op.allParams || op.hasFormParams},{/if}
+            {#for arg in additionalRequestArgs}
+                {arg}{#if arg_hasNext}, {/if}
+            {/for}
+            {#if is-resteasy-reactive && use-dynamic-url}, {/if}
         {/if}
         {#if is-resteasy-reactive && use-dynamic-url}
         // See https://quarkus.io/version/3.20/guides/rest-client#dynamic-base-urls


### PR DESCRIPTION
This PR fixes  #1161 

When using both `additional-request-args` and `use-dynamic-url=true`, the generated REST client method was missing a comma between the parameters, causing a compilation error.

This update to the `api.qute` template ensures that:
- A comma is correctly added between `additionalRequestArgs` and `@Url`
- No extra commas are introduced
- Other parameter combinations are unaffected

