### PR TITLE
Fix #1087 - Paths file when generating Java files on Windows

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/OpenApiNamespaceResolver.java
@@ -1,7 +1,7 @@
 package io.quarkiverse.openapi.generator.deployment.template;
 
-import java.io.File;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +61,7 @@ public class OpenApiNamespaceResolver implements NamespaceResolver {
 
     @SuppressWarnings("unused")
     public String parseUri(String uri) {
-        return OpenApiGeneratorOutputPaths.getRelativePath(Path.of(uri)).toString().replace(File.separatorChar, '/');
+        return OpenApiGeneratorOutputPaths.getRelativePath(Path.of(URI.create(uri))).toString();
     }
 
     @SuppressWarnings("unused")

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -64,7 +64,8 @@ public abstract class OpenApiClientGeneratorWrapper {
         GlobalSettings.setProperty(ONCE_LOGGER, verbose ? FALSE.toString() : TRUE.toString());
 
         this.configurator = configurator;
-        this.configurator.setInputSpec(specFilePath.toString());
+        // toUri() for the input first to ensure consistent path names which became an issue with the 3.1.0 spec-parser
+        this.configurator.setInputSpec(specFilePath.toUri().toString());
         this.configurator.setOutputDir(outputDir.toString());
         this.configurator.addAdditionalProperty(QUARKUS_GENERATOR_NAME,
                 Collections.singletonMap("openApiSpecId", getSanitizedFileName(specFilePath)));


### PR DESCRIPTION
Fix #1047 

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
This fixes issues with generating openapi spec 3.1.0 versions on Windows, e.g. #1047 
</summary>

Please backport this to the main LTS release as well - I don't seem to be able to set a label?
I've tested this on my own simple project. 

https://github.com/jcjveraa/quarkus-openapi-generator-demoapp

Without this fix (on windows on version 2.10.0-lts): java.net.URISyntaxException: Illegal character in opaque part at index 2: C:\(...)
With (on local build of 3.0.0-SNAPSHOT): it works fine.

No tests added 
</details>
