### PR TITLE
Prepare release 2.11.0-lts

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.10.0-lts
+  current-version: 2.11.0-lts
   next-version: 3.0.0-lts-SNAPSHOT


### PR DESCRIPTION
@hbelmiro @ricardozanini feel free to delete this if you feel it's too forward and just take it as a request :) 
I'm "actively waiting" for my fix #1190 to be released officially such that I can use this in my projects without manual intervention. Gleaning at eg #1136 this seems to trigger the pipeline for a release. 

_The Openapi spec of my quarkus server project is generated as a 3.1.0 version, for which my client app generates the API-interfaces using this project. Which doesn't work without this fix on my Windows development machine. Our work policy is to use only 'official builds' of libraries, not a DIY version, hence my 'need' for the fixed version to be released._