### PR TITLE
Add documentation about the use-bean-validation property

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server.adoc
@@ -70,6 +70,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-builders]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-builders[`quarkus.openapi.generator.builders`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi.generator.builders+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether it must generate builders for properties.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_BUILDERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_BUILDERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-base-package]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-base-package[`quarkus.openapi.generator.base-package`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi.generator.base-package+++[]
@@ -90,6 +111,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`io.apicurio.api`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-use-bean-validation]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-use-bean-validation[`quarkus.openapi.generator.use-bean-validation`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi.generator.use-bean-validation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether it must generate resources and beans using bean validation (JSR-303).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_USE_BEAN_VALIDATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_USE_BEAN_VALIDATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server_quarkus.openapi.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server_quarkus.openapi.adoc
@@ -70,6 +70,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-builders]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-builders[`quarkus.openapi.generator.builders`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi.generator.builders+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether it must generate builders for properties.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_BUILDERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_BUILDERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-base-package]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-base-package[`quarkus.openapi.generator.base-package`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi.generator.base-package+++[]
@@ -90,6 +111,27 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`io.apicurio.api`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator-server_quarkus-openapi-generator-use-bean-validation]] [.property-path]##link:#quarkus-openapi-generator-server_quarkus-openapi-generator-use-bean-validation[`quarkus.openapi.generator.use-bean-validation`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi.generator.use-bean-validation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether it must generate resources and beans using bean validation (JSR-303).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_USE_BEAN_VALIDATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_USE_BEAN_VALIDATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
 
 |===
 


### PR DESCRIPTION
This pull request adds missing documentation about the property `use-bean-validation`. 