### PR TITLE
Add Security Scheme type: openIdConnect

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -77,7 +77,8 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
             if (ProcessUtils.hasHttpBasicMethods(this.openAPI) ||
                     ProcessUtils.hasApiKeyMethods(this.openAPI) ||
                     ProcessUtils.hasHttpBearerMethods(this.openAPI) ||
-                    ProcessUtils.hasOAuthMethods(this.openAPI)) {
+                    ProcessUtils.hasOAuthMethods(this.openAPI) ||
+                    ProcessUtils.hasOpenIdConnectMethods(this.openAPI)) {
                 supportingFiles.add(
                         new SupportingFile(AUTH_PACKAGE + "/compositeAuthenticationProvider.qute",
                                 authFileFolder(),

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/auth/compositeAuthenticationProvider.qute
@@ -4,6 +4,9 @@ package {apiPackage}.auth;
 {#for auth in openapi:getUniqueOAuthOperations(oauthMethods.orEmpty)}
 @io.quarkiverse.openapi.generator.markers.OauthAuthenticationMarker(name="{auth.name}", openApiSpecId="{quarkus-generator.openApiSpecId}")
 {/for}
+{#for auth in openapi:getUniqueOAuthOperations(openIdConnectMethods.orEmpty)}
+@io.quarkiverse.openapi.generator.markers.OauthAuthenticationMarker(name="{auth.name}", openApiSpecId="{quarkus-generator.openApiSpecId}")
+{/for}
 {#for auth in httpBasicMethods.orEmpty}
 @io.quarkiverse.openapi.generator.markers.BasicAuthenticationMarker(name="{auth.name}", openApiSpecId="{quarkus-generator.openApiSpecId}")
 {/for}

--- a/client/integration-tests/auth-provider/src/main/java/io/quarkiverse/openapi/generator/it/auth/TokenServerResource.java
+++ b/client/integration-tests/auth-provider/src/main/java/io/quarkiverse/openapi/generator/it/auth/TokenServerResource.java
@@ -20,6 +20,9 @@ public class TokenServerResource {
     @RestClient
     org.acme.externalservice5.api.DefaultApi defaultApi5;
 
+    @RestClient
+    org.acme.externalservice6.api.DefaultApi defaultApi6;
+
     @POST
     @Path("service1")
     public String service1() {
@@ -45,6 +48,13 @@ public class TokenServerResource {
     @Path("service5")
     public String service5() {
         defaultApi5.executeQuery5();
+        return "hello";
+    }
+
+    @POST
+    @Path("service6")
+    public String service6() {
+        defaultApi6.executeQuery6();
         return "hello";
     }
 }

--- a/client/integration-tests/auth-provider/src/main/openapi/token-external-service6.yaml
+++ b/client/integration-tests/auth-provider/src/main/openapi/token-external-service6.yaml
@@ -1,0 +1,20 @@
+---
+openapi: 3.0.3
+info:
+  title: token-external-service6 API
+  version: 3.0.0-SNAPSHOT
+paths:
+  /token-external-service6/executeQuery6:
+    post:
+      operationId: executeQuery6
+      responses:
+        "200":
+          description: OK
+      security:
+        - service6-oidc: []
+components:
+  securitySchemes:
+    service6-oidc:
+        type: openIdConnect
+        description: Authentication for service6
+        openIdConnectUrl: https://example.com/realms/master/.well-known/openid-configuration

--- a/client/integration-tests/auth-provider/src/main/resources/application.properties
+++ b/client/integration-tests/auth-provider/src/main/resources/application.properties
@@ -6,11 +6,13 @@ quarkus.openapi-generator.codegen.spec.token_external_service1_yaml.base-package
 quarkus.openapi-generator.codegen.spec.token_external_service2_yaml.base-package=org.acme.externalservice2
 quarkus.openapi-generator.codegen.spec.token_external_service3_yaml.base-package=org.acme.externalservice3
 quarkus.openapi-generator.codegen.spec.token_external_service5_yaml.base-package=org.acme.externalservice5
+quarkus.openapi-generator.codegen.spec.token_external_service6_yaml.base-package=org.acme.externalservice6
 
 quarkus.rest-client.token_external_service1_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_external_service2_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_external_service3_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_external_service5_yaml.url=${propagation-external-service-mock.url}
+quarkus.rest-client.token_external_service6_yaml.url=${propagation-external-service-mock.url}
 
 # default propagation for token_external_service1 invocation
 quarkus.openapi-generator.token_external_service1_yaml.auth.service1_http_bearer.token-propagation=true
@@ -38,5 +40,16 @@ quarkus.oidc-client.service5_oauth2.client-id=kogito-app
 quarkus.oidc-client.service5_oauth2.grant.type=client
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.method=basic
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.value=secret
+
+
+# Oidc client used by the token_external_service6
+quarkus.oidc-client.service6_oidc.auth-server-url=${keycloak.mock.service.url}
+quarkus.oidc-client.service6_oidc.token-path=${keycloak.mock.service.token-path}
+quarkus.oidc-client.service6_oidc.discovery-enabled=false
+quarkus.oidc-client.service6_oidc.client-id=kogito-app
+quarkus.oidc-client.service6_oidc.grant.type=client
+quarkus.oidc-client.service6_oidc.credentials.client-secret.method=basic
+quarkus.oidc-client.service6_oidc.credentials.client-secret.value=secret
+
 
 quarkus.keycloak.devservices.enabled=false

--- a/client/integration-tests/auth-provider/src/test/java/io/quarkiverse/openapi/generator/it/auth/TokenExternalServicesMock.java
+++ b/client/integration-tests/auth-provider/src/test/java/io/quarkiverse/openapi/generator/it/auth/TokenExternalServicesMock.java
@@ -60,6 +60,11 @@ public class TokenExternalServicesMock implements QuarkusTestResourceLifecycleMa
         // configured. The token will be overridden by the custom credential provider
         stubForExternalService("/token-external-service5/executeQuery5", KEYCLOAK_ACCESS_TOKEN + "_TEST");
 
+        // stub the token-external-service6 invocation with the expected token, no propagation is produced
+        // in this case but the service must receive the token provided by Keycloak since it has oidc security
+        // configured. The token will be overridden by the custom credential provider
+        stubForExternalService("/token-external-service6/executeQuery6", KEYCLOAK_ACCESS_TOKEN + "_TEST");
+
         return Map.of(TOKEN_EXTERNAL_SERVICE_MOCK_URL, wireMockServer.baseUrl());
     }
 

--- a/client/integration-tests/auth-provider/src/test/java/io/quarkiverse/openapi/generator/it/auth/TokenWithCustomCredentialProviderTest.java
+++ b/client/integration-tests/auth-provider/src/test/java/io/quarkiverse/openapi/generator/it/auth/TokenWithCustomCredentialProviderTest.java
@@ -22,7 +22,7 @@ import io.quarkus.test.junit.QuarkusTest;
 class TokenWithCustomCredentialProviderTest {
 
     @ParameterizedTest
-    @ValueSource(strings = { "service1", "service2", "service3", "service5" })
+    @ValueSource(strings = { "service1", "service2", "service3", "service5", "service6" })
     void testService(String service) {
         Map<String, String> headers = Map.of(HttpHeaders.AUTHORIZATION, AUTHORIZATION_TOKEN);
 

--- a/client/integration-tests/security/src/main/java/io/quarkiverse/openapi/generator/it/security/TokenPropagationResource.java
+++ b/client/integration-tests/security/src/main/java/io/quarkiverse/openapi/generator/it/security/TokenPropagationResource.java
@@ -24,6 +24,9 @@ public class TokenPropagationResource {
     @RestClient
     org.acme.externalservice5.api.DefaultApi defaultApi5;
 
+    @RestClient
+    org.acme.externalservice6.api.DefaultApi defaultApi6;
+
     @POST
     @Path("service1")
     public Response service1() {
@@ -52,5 +55,11 @@ public class TokenPropagationResource {
     @Path("service5")
     public Response service5() {
         return defaultApi5.executeQuery5();
+    }
+
+    @POST
+    @Path("service6")
+    public Response service6() {
+        return defaultApi6.executeQuery6();
     }
 }

--- a/client/integration-tests/security/src/main/openapi/token-propagation-external-service6.yaml
+++ b/client/integration-tests/security/src/main/openapi/token-propagation-external-service6.yaml
@@ -1,0 +1,20 @@
+---
+openapi: 3.0.3
+info:
+  title: external-service6 API
+  version: 3.0.0-SNAPSHOT
+paths:
+  /token-propagation-external-service6/executeQuery6:
+    post:
+      operationId: executeQuery6
+      responses:
+        "200":
+          description: OK
+      security:
+        - service6-oidc: []
+components:
+  securitySchemes:
+    service6-oidc:
+      type: openIdConnect
+      description: Authentication for service6
+      openIdConnectUrl: https://example.com/realms/master/.well-known/openid-configuration

--- a/client/integration-tests/security/src/main/resources/application.properties
+++ b/client/integration-tests/security/src/main/resources/application.properties
@@ -32,12 +32,15 @@ quarkus.openapi-generator.codegen.spec.token_propagation_external_service2_yaml.
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service3_yaml.base-package=org.acme.externalservice3
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service4_yaml.base-package=org.acme.externalservice4
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service5_yaml.base-package=org.acme.externalservice5
+quarkus.openapi-generator.codegen.spec.token_propagation_external_service6_yaml.base-package=org.acme.externalservice6
 
 quarkus.rest-client.token_propagation_external_service1_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service2_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service3_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service4_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service5_yaml.url=${propagation-external-service-mock.url}
+quarkus.rest-client.token_propagation_external_service6_yaml.url=${propagation-external-service-mock.url}
+
 
 # default propagation for token_propagation_external_service1 invocation
 quarkus.openapi-generator.token_propagation_external_service1_yaml.auth.service1_http_bearer.token-propagation=true
@@ -77,6 +80,15 @@ quarkus.oidc-client.service5_oauth2.client-id=kogito-app
 quarkus.oidc-client.service5_oauth2.grant.type=client
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.method=basic
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.value=secret
+
+# Oidc client used by the token_propagation_external_service6
+quarkus.oidc-client.service6_oidc.auth-server-url=${keycloak.mock.service.url}
+quarkus.oidc-client.service6_oidc.token-path=${keycloak.mock.service.token-path}
+quarkus.oidc-client.service6_oidc.discovery-enabled=false
+quarkus.oidc-client.service6_oidc.client-id=kogito-app
+quarkus.oidc-client.service6_oidc.grant.type=client
+quarkus.oidc-client.service6_oidc.credentials.client-secret.method=basic
+quarkus.oidc-client.service6_oidc.credentials.client-secret.value=secret
 
 quarkus.keycloak.devservices.enabled=false
 

--- a/client/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/TokenPropagationExternalServicesMock.java
+++ b/client/integration-tests/security/src/test/java/io/quarkiverse/openapi/generator/it/security/TokenPropagationExternalServicesMock.java
@@ -66,6 +66,11 @@ public class TokenPropagationExternalServicesMock implements QuarkusTestResource
         // configured.
         stubForExternalService("/token-propagation-external-service5/executeQuery5", KEYCLOAK_ACCESS_TOKEN);
 
+        // stub the token-propagation-external-service6 invocation with the expected token, no propagation is produced
+        // in this case but the service must receive the token provided by Keycloak since it has oidc security
+        // configured.
+        stubForExternalService("/token-propagation-external-service6/executeQuery6", KEYCLOAK_ACCESS_TOKEN);
+
         return Map.of(TOKEN_PROPAGATION_EXTERNAL_SERVICE_MOCK_URL, wireMockServer.baseUrl());
     }
 


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/issues/1227

Add to the template and codegen to look for and use the openIdConnectMethods
Add Integration tests to verify support