### PR TITLE
Bump to openapi-generator 7.15

### DIFF
--- a/client/deployment/pom.xml
+++ b/client/deployment/pom.xml
@@ -11,7 +11,7 @@
   <name>Quarkus - OpenAPI Generator - Client - Deployment</name>
 
   <properties>
-    <version.org.openapitools>7.14.0</version.org.openapitools>
+    <version.org.openapitools>7.15.0</version.org.openapitools>
     <version.org.slf4j>2.0.17</version.org.slf4j>
     <version.com.github.jknack>4.3.1</version.com.github.jknack>
   </properties>

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -57,6 +57,7 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
         this.sourceFolder = "";
         this.testFolder = "";
         this.embeddedTemplateDir = "templates";
+        this.supportsAdditionalPropertiesWithComposedSchema = false;
 
         Boolean beanValidation = (Boolean) this.additionalProperties.getOrDefault("use-bean-validation", false);
 


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-openapi-generator/pull/1289

I set the `supportsAdditionalPropertiesWithComposedSchema` to false to keep the same behavior we already have. I didn't do a throughout review, but we already support `additionalProperties` in the schema in a composite way: https://docs.quarkiverse.io/quarkus-openapi-generator/dev/client.html#additional-properties.

So setting `additional-properties-as-attribute=true` will prevent the model from extending a `HashMap`.

See: https://github.com/OpenAPITools/openapi-generator/commit/304b3cbcaa6397a0ffc96ebe91f2678017df19fd