### PR TITLE
Remove  annotation due Quarkus only supports CDI-lite specification

### DIFF
--- a/client/integration-tests/auth-provider/src/main/java/io/quarkiverse/openapi/generator/it/auth/provider/CustomCredentialsProvider.java
+++ b/client/integration-tests/auth-provider/src/main/java/io/quarkiverse/openapi/generator/it/auth/provider/CustomCredentialsProvider.java
@@ -5,14 +5,12 @@ import java.util.Optional;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
-import jakarta.enterprise.inject.Specializes;
 
 import io.quarkiverse.openapi.generator.providers.ConfigCredentialsProvider;
 import io.quarkiverse.openapi.generator.providers.CredentialsContext;
 
 @Dependent
 @Alternative
-@Specializes
 @Priority(201)
 public class CustomCredentialsProvider extends ConfigCredentialsProvider {
     public CustomCredentialsProvider() {

--- a/docs/modules/ROOT/pages/includes/custom-auth-provider.adoc
+++ b/docs/modules/ROOT/pages/includes/custom-auth-provider.adoc
@@ -27,7 +27,7 @@ import io.quarkiverse.openapi.generator.providers.CredentialsProvider;
 
 @RequestScoped
 @Alternative
-@Priority(200) // A higher priority than the default provider.
+@Priority(200) // <1>
 public class RuntimeCredentialsProvider implements CredentialsProvider {
 
     @Override
@@ -57,6 +57,8 @@ public class RuntimeCredentialsProvider implements CredentialsProvider {
     }
 }
 ----
+
+<1> Note the `@Priority(200)` annotation. This ensures that your custom provider takes precedence over the default implementation.
 
 == How It Works
 


### PR DESCRIPTION
I am removing the `@Specializes` annotation, due to Quarkus only supports CDI-lite.

Additionally, I added an advice the user in the documentation about the precedence over the default implementation.

This pull request aims to unblock the https://github.com/quarkiverse/quarkus-openapi-generator/pull/1368 pull request.