### PR TITLE
Update permissions in label-new-pr workflow to include pull-requests

### DIFF
--- a/.github/workflows/label-new-pr.yml
+++ b/.github/workflows/label-new-pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:  
   issues: write
+  pull-requests: write
 
 jobs:
   add_label:


### PR DESCRIPTION
related to issue #1174  and pr #1406 

The problem is related to permissions, which is why the workflow probably didn't work. I ran a simulation script for that specific problem and it worked.

