### PR TITLE
Add io.quarkus:quarkus-rest-client-jackson as required dependency on client codestart

### DIFF
--- a/client/runtime/src/main/codestarts/quarkus/openapi-generator-codestart/codestart.yml
+++ b/client/runtime/src/main/codestarts/quarkus/openapi-generator-codestart/codestart.yml
@@ -6,3 +6,7 @@ metadata:
   title: OpenAPI Generator Client Codestart
   description: Start to code with the OpenAPI Generator Client extension.
   related-guide-section: https://docs.quarkiverse.io/quarkus-openapi-generator/dev/client.html
+language:
+  base:
+    dependencies:
+      - io.quarkus:quarkus-rest-client-jackson

--- a/client/runtime/src/main/codestarts/quarkus/openapi-generator-codestart/java/README.tpl.qute.md
+++ b/client/runtime/src/main/codestarts/quarkus/openapi-generator-codestart/java/README.tpl.qute.md
@@ -1,48 +1,7 @@
 {#include readme-header /}
 
-## Requirements
+## Quarkus OpenAPI Generator Client
 
-If you do not have added the `io.quarkus:quarkus-rest-client-jackson` or `io.quarkus:quarkus-rest-client-reactive-jackson` extension in your project, add it first:
+The Codestart adds automatically the `io.quarkus:quarkus-rest-client-jackson` dependency to a generated project, this dependency is required for generating the [REST Client](https://quarkus.io/guides/rest-client) classes. 
 
-Remember, you just need to add one of them, depending on your needs.
-
-### REST Client Jackson:
-
-Quarkus CLI:
-
-```bash
-quarkus ext add io.quarkus:quarkus-rest-client-jackson
-```
-
-Maven:
-```bash
-./mvnw quarkus:add-extension -Dextensions="io.quarkus:quarkus-rest-client-jackson"
-```
-
-Gradle:
-
-```bash
-./gradlew addExtension --extensions="io.quarkus:quarkus-rest-client-jackson"
-```
-
-or
-
-### REST Client Reactive Jackson:
-
-Quarkus CLI:
-
-```bash
-quarkus ext add io.quarkus:quarkus-rest-client-reactive-jackson
-```
-
-Maven:
-
-```bash
-./mvnw quarkus:add-extension -Dextensions="io.quarkus:quarkus-rest-client-reactive-jackson"
-```
-
-Gradle:
-
-```bash
-./gradlew addExtension --extensions="io.quarkus:quarkus-rest-client-reactive-jackson"
-```
+For more information about how to use the Quarkus OpenAPI Generator Client extension, please refer to [Quarkus OpenAPI Generator Client documentation](https://docs.quarkiverse.io/quarkus-openapi-generator/dev/client.html).


### PR DESCRIPTION
# Changes

* Add `io.quarkus:quarkus-rest-client-jackson` as required dependency on client codestarts.
* Remove reference to old https://quarkus.io/guides/resteasy-client REST client when generating the codestart.
