### PR TITLE
[NO-ISSUE] Sync documentation properties

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
@@ -183,7 +183,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Defines if the methods should return `jakarta.ws.rs.core.Response` or a model. Default is `false`.
+Defines if the methods should return `jakarta.ws.rs.core.Response`, `org.jboss.resteasy.reactive.RestResponse` or a model. By default, it returns the model in the specification.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -193,7 +193,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_RETURN_RESPONSE+++`
 endif::add-copy-button-to-env-var[]
 --
-|boolean
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-enable-security-generation]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-enable-security-generation[`quarkus.openapi-generator.codegen.enable-security-generation`]##
@@ -267,7 +267,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Defines with SmallRye Mutiny enabled if methods should return `jakarta.ws.rs.core.Response` or a model. Default is `false`.
+Defines with SmallRye Mutiny enabled if methods should return `jakarta.ws.rs.core.Response`, `org.jboss.resteasy.reactive.RestResponse` or a model. By default, it returns the model in the specification.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -277,7 +277,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_MUTINY_RETURN_RESPONSE+++`
 endif::add-copy-button-to-env-var[]
 --
-|boolean
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny-operation-ids-mutiny-multi-operation-ids]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny-operation-ids-mutiny-multi-operation-ids[`quarkus.openapi-generator.codegen.mutiny.operation-ids."mutiny-multi-operation-ids"`]##
@@ -290,11 +290,11 @@ endif::add-copy-button-to-config-props[]
 --
 Handles the return type for each operation, depending on the configuration. The following cases are supported:
 
-1. If `mutiny` is enabled and the operation ID is specified to return `Multi`: - The return type will be wrapped in `io.smallrye.mutiny.Multi`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Multi<returnType>`.
+1. If `mutiny` is enabled and the operation ID is specified to return `Multi`: - The return type will be wrapped in `io.smallrye.mutiny.Multi`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Multi<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Multi<returnType>`.
 
-2. If `mutiny` is enabled and the operation ID is specified to return `Uni`: - The return type will be wrapped in `io.smallrye.mutiny.Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>`.
+2. If `mutiny` is enabled and the operation ID is specified to return `Uni`: - The return type will be wrapped in `io.smallrye.mutiny.Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>`.
 
-3. If `mutiny` is enabled but no specific operation ID is configured for `Multi` or `Uni`: - The return type defaults to `Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>``.
+3. If `mutiny` is enabled but no specific operation ID is configured for `Multi` or `Uni`: - The return type defaults to `Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>``.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -950,7 +950,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Defines if the methods should return `jakarta.ws.rs.core.Response` or a model. Default is `false`.
+Defines if the methods should return `jakarta.ws.rs.core.Response`, `org.jboss.resteasy.reactive.RestResponse` or a model. By default, it returns the model in the specification.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -960,7 +960,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__RETURN_RESPONSE+++`
 endif::add-copy-button-to-env-var[]
 --
-|boolean
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-enable-security-generation]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-enable-security-generation[`quarkus.openapi-generator.codegen.spec."spec-item".enable-security-generation`]##
@@ -1034,7 +1034,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Defines with SmallRye Mutiny enabled if methods should return `jakarta.ws.rs.core.Response` or a model. Default is `false`.
+Defines with SmallRye Mutiny enabled if methods should return `jakarta.ws.rs.core.Response`, `org.jboss.resteasy.reactive.RestResponse` or a model. By default, it returns the model in the specification.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1044,7 +1044,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__MUTINY_RETURN_RESPONSE+++`
 endif::add-copy-button-to-env-var[]
 --
-|boolean
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny-operation-ids-mutiny-multi-operation-ids]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny-operation-ids-mutiny-multi-operation-ids[`quarkus.openapi-generator.codegen.spec."spec-item".mutiny.operation-ids."mutiny-multi-operation-ids"`]##
@@ -1057,11 +1057,11 @@ endif::add-copy-button-to-config-props[]
 --
 Handles the return type for each operation, depending on the configuration. The following cases are supported:
 
-1. If `mutiny` is enabled and the operation ID is specified to return `Multi`: - The return type will be wrapped in `io.smallrye.mutiny.Multi`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Multi<returnType>`.
+1. If `mutiny` is enabled and the operation ID is specified to return `Multi`: - The return type will be wrapped in `io.smallrye.mutiny.Multi`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Multi<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Multi<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Multi<returnType>`.
 
-2. If `mutiny` is enabled and the operation ID is specified to return `Uni`: - The return type will be wrapped in `io.smallrye.mutiny.Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>`.
+2. If `mutiny` is enabled and the operation ID is specified to return `Uni`: - The return type will be wrapped in `io.smallrye.mutiny.Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>`.
 
-3. If `mutiny` is enabled but no specific operation ID is configured for `Multi` or `Uni`: - The return type defaults to `Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>``.
+3. If `mutiny` is enabled but no specific operation ID is configured for `Multi` or `Uni`: - The return type defaults to `Uni`. - If `mutiny.return-response` is enabled, the return type will be `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<jakarta.ws.rs.core.Response>`. - If `mutiny.return-response` is set to `RestResponse`, the return type will be `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<returnType>>`. - If the operation has a void return type, it will return `io.smallrye.mutiny.Uni<org.jboss.resteasy.reactive.RestResponse<java.lang.Void>>`. - Otherwise, it will return `io.smallrye.mutiny.Uni<returnType>``.
 
 
 ifdef::add-copy-button-to-env-var[]


### PR DESCRIPTION
# Changes

Sync the client configuration with the documentation. It should have been uploaded in a previous pull request, I am uploading it now to solve some question about this file in new/opened pull requests.

# Checklist

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
