### PR TITLE
Add permissions to backport GHA

### DIFF
--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -3,6 +3,11 @@ name: Pull Request Backporting
 on:
   pull_request_target:
     types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to explicitly set the required permissions for the workflow to function properly.

Workflow permissions update:

* [`.github/workflows/pr-backporting.yml`](diffhunk://#diff-da3d87773e13508d9ac9396466da2f435481735b38a8f891a22ee42634bf890dR6-R10): Added `contents: write` and `pull-requests: write` permissions to ensure the workflow can modify repository contents and manage pull requests.