### PR TITLE
[main-lts] Upgrade Quarkus to 3.33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <apicurio.version>1.2.11.Final</apicurio.version>
-    <quarkus.version>3.27.2</quarkus.version>
+    <quarkus.version>3.33.1</quarkus.version>
 
     <version.maven.install.plugin>3.1.4</version.maven.install.plugin>
     <version.com.github.javaparser>3.28.0</version.com.github.javaparser>


### PR DESCRIPTION
This pull request updates the Quarkus framework version used by the project. The change is limited to a single dependency version bump in the `pom.xml` file.

- Dependency update:
  * Upgraded the Quarkus version from `3.27.2` to `3.33.1` in the `pom.xml` file.