### PR TITLE
[NO-ISSUE] Update preview and teardown documentation

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,48 +2,66 @@ name: Surge.sh Preview
 
 on:
   workflow_run:
-    workflows: ["Build Website"]
+    workflows: [ "Build Website" ]
     types:
       - completed
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.name == 'Build Website'
+    permissions:
+      pull-requests: write # Required to update PR status comment
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v20
+        uses: actions/download-artifact@v8
         with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
           name: site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download PR ID Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-id
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
       - name: Store PR id as variable
         id: pr
         run: |
-          echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT 
-          rm -f pr-id.txt
+          echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
+
       - name: Publishing to surge for preview
         id: deploy
-        run: npx surge ./ --domain https://quarkus-openapi-generator-preview-pr-${{  steps.pr.outputs.id }}.surge.sh --token ${{ secrets.SURGE_LOCAL_TOKEN }}
+        run: npx surge ./ --domain https://quarkiverse-openapi-generator-preview-pr-${{ steps.pr.outputs.id }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
       - name: Update PR status comment on success
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: quarkusio/action-helpers@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.id }}
           body: |
-            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed. See the documentation preview: https://quarkus-openapi-generator-preview-pr-${{ steps.pr.outputs.id }}.surge.sh
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ steps.pr.outputs.id }}
-          emojis: 'heart'
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkiverse-flow-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+
+            <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
+          body-marker: <!-- Preview status comment marker -->
       - name: Update PR status comment on failure
+        uses: quarkusio/action-helpers@main
         if: ${{ failure() }}
-        uses: actions-cool/maintain-one-comment@v3.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.id }}
           body: |
             😭 Deploy PR Preview failed.
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ steps.pr.outputs.id }}
-          emojis: 'confused'
+          body-marker: <!-- Preview status comment marker -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,19 +18,13 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.name == 'Build Website'
     permissions:
-      pull-requests: write # Required to update PR status comment
+      actions: read
+      pull-requests: write
     steps:
       - name: Download PR Artifact
         uses: actions/download-artifact@v8
         with:
           name: site
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Download PR ID Artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: pr-id
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
@@ -50,7 +44,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.id }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkiverse-flow-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkiverse-openapi-generator-preview-pr-${{ steps.pr.outputs.id }}.surge.sh
 
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
           body-marker: <!-- Preview status comment marker -->

--- a/.github/workflows/preview_teardown.yml
+++ b/.github/workflows/preview_teardown.yml
@@ -1,24 +1,34 @@
-name: Surge.sh Preview Teardown
+name: Surge.sh Teardown
 
 on:
   pull_request_target:
-    paths:
-      - '*.adoc'
     types: [closed]
 
 jobs:
-  preview-teardown:
+  preview:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://quarkus-openapi-generator-preview-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-      - name: Update PR status comment
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        run: npx surge teardown https://quarkiverse-openapi-generator-preview-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+      - name: Update PR status comment on success
+        uses: quarkusio/action-helpers@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.number }}
           body: |
             🙈 The PR is closed and the preview is expired.
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ github.event.number }}
+          body-marker: <!-- Preview status comment marker -->
+      - name: Update PR status comment on failure
+        uses: quarkusio/action-helpers@main
+        if: ${{ failure() }}
+        with:
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.number }}
+          body: |
+            😭 Failed to teardown preview for this PR. Please check the workflow logs.
+          body-marker: <!-- Preview status comment marker -->


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for preview deployment and teardown, improving security, maintainability, and consistency in PR preview management. The main changes include switching to official and maintained actions, updating naming and domain conventions, and enhancing PR status comment handling.

**Preview deployment workflow improvements:**

* Switched from `dawidd6/action-download-artifact` to the official `actions/download-artifact` action for downloading artifacts, and updated artifact download parameters for better reliability and security.
* Updated the deployment domain from `quarkus-openapi-generator-preview-pr-` to `quarkiverse-openapi-generator-preview-pr-` for consistency with project naming.
* Replaced `actions-cool/maintain-one-comment` with `quarkusio/action-helpers` for managing PR status comments, and improved the comment content and marker for better clarity.
* Added explicit job permissions for `actions: read` and `pull-requests: write` to follow GitHub security best practices.
* Improved workflow trigger conditions to ensure the preview is only deployed after a successful "Build Website" workflow run.

**Preview teardown workflow improvements:**

* Updated the teardown domain to match the new naming convention and switched to `quarkusio/action-helpers` for PR comment management, including separate handling for success and failure cases.
* Added `pull-requests: write` permission to the teardown job for secure comment updates.
* Simplified workflow naming and job structure for clarity.