### PR TITLE
Only execute preview workflow when base ref is main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,8 @@ jobs:
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.name == 'Build Website'
+      github.event.workflow_run.name == 'Build Website' &&
+      github.event.workflow_run.head_branch == 'main'
     permissions:
       actions: read
       pull-requests: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.name == 'Build Website' &&
-      github.event.workflow_run.head_branch == 'main'
+      github.event.workflow_run.pull_requests[0].base.ref == 'main'
     permissions:
       actions: read
       pull-requests: write


### PR DESCRIPTION
This pull request makes a targeted update to the workflow trigger conditions in `.github/workflows/preview.yml`. The change ensures that the workflow only proceeds when the pull request is targeting the `main` branch.

Workflow trigger refinement:

* Updated the condition so that the workflow only runs if the pull request's base branch is `main`, adding an extra safeguard to prevent unintended runs on other branches.