### PR TITLE
Ignore preview teardown when PR target is main-lts

### DIFF
--- a/.github/workflows/preview_teardown.yml
+++ b/.github/workflows/preview_teardown.yml
@@ -3,6 +3,8 @@ name: Surge.sh Teardown
 on:
   pull_request_target:
     types: [closed]
+    branches-ignore:
+      - main-lts
 
 jobs:
   preview:


### PR DESCRIPTION
# Changes

Ignore preview_teardown.yml to execute when the target branch is `main-lts`.