### PR TITLE
[NO-ISSUE] Add version matrix

### DIFF
--- a/.github/update-version-matrix.sh
+++ b/.github/update-version-matrix.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly README_FILE="README.md"
+readonly START_MARKER="<!-- VERSION-MATRIX:START -->"
+readonly END_MARKER="<!-- VERSION-MATRIX:END -->"
+
+usage() {
+  echo "Usage: $0 <project-version> <quarkus-version>" >&2
+  exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+project_version="$1"
+quarkus_version="$2"
+
+if [[ ! "${project_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-lts)?$ ]]; then
+  echo "Invalid project version: ${project_version}" >&2
+  exit 1
+fi
+
+if [[ ! "${quarkus_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9]+)?$ ]]; then
+  echo "Invalid Quarkus version: ${quarkus_version}" >&2
+  exit 1
+fi
+
+release_type="Normal"
+if [[ "${project_version}" == *-lts ]]; then
+  release_type="LTS"
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ ! -f "${README_FILE}" ]]; then
+  echo "README.md not found" >&2
+  exit 1
+fi
+
+python3 - "${README_FILE}" "${START_MARKER}" "${END_MARKER}" "${project_version}" "${quarkus_version}" "${release_type}" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+readme_path = Path(sys.argv[1])
+start_marker = sys.argv[2]
+end_marker = sys.argv[3]
+project_version = sys.argv[4]
+quarkus_version = sys.argv[5]
+release_type = sys.argv[6]
+
+content = readme_path.read_text()
+
+start = content.find(start_marker)
+end = content.find(end_marker)
+if start == -1 or end == -1 or end < start:
+    raise SystemExit("Invalid version matrix markers in README.md")
+
+end += len(end_marker)
+section = content[start:end]
+
+row_pattern = re.compile(r"^\| ([^|]+) \| ([^|]+) \| ([^|]+) \|$")
+rows = []
+
+for line in section.splitlines():
+    match = row_pattern.match(line.strip())
+    if not match:
+        continue
+    version = match.group(1).strip()
+    if version == "Project version":
+        continue
+    rows.append(
+        {
+            "version": version,
+            "type": match.group(2).strip(),
+            "quarkus": match.group(3).strip(),
+        }
+    )
+
+updated = False
+for row in rows:
+    if row["version"] == project_version:
+        row["type"] = release_type
+        row["quarkus"] = quarkus_version
+        updated = True
+        break
+
+if not updated:
+    rows.append(
+        {
+            "version": project_version,
+            "type": release_type,
+            "quarkus": quarkus_version,
+        }
+    )
+
+def version_key(value: str):
+    raw = value[:-4] if value.endswith("-lts") else value
+    parts = tuple(int(part) for part in raw.split("."))
+    is_lts = 1 if value.endswith("-lts") else 0
+    return (*parts, is_lts)
+
+rows.sort(key=lambda row: version_key(row["version"]), reverse=True)
+
+lines = [
+    start_marker,
+    "The project keeps normal releases and `-lts` releases aligned with specific Quarkus streams.",
+    "",
+    "| Project version | Type | Quarkus version |",
+    "|---|---|---|",
+]
+
+for row in rows:
+    lines.append(f"| {row['version']} | {row['type']} | {row['quarkus']} |")
+
+lines.extend(
+    [
+        "",
+        "The matrix above is maintained via workflow dispatch using the informed project version and Quarkus version.",
+        end_marker,
+    ]
+)
+
+replacement = "\n".join(lines)
+updated_content = content[:start] + replacement + content[end:]
+
+if updated_content != content:
+    readme_path.write_text(updated_content)
+PY
+
+echo "Updated ${README_FILE} version matrix for ${project_version} -> ${quarkus_version}"

--- a/.github/workflows/update-version-matrix.yml
+++ b/.github/workflows/update-version-matrix.yml
@@ -1,0 +1,60 @@
+name: Update Version Matrix
+
+on:
+  workflow_dispatch:
+    inputs:
+      project-version:
+        description: 'Project version to add/update in README matrix (for example: 2.15.0 or 2.15.0-lts)'
+        required: true
+        type: string
+      quarkus-version:
+        description: 'Quarkus version to associate with the project version (for example: 3.33.1)'
+        required: true
+        type: string
+
+jobs:
+  update-version-matrix:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Ensure script is executable
+        run: chmod +x .github/update-version-matrix.sh
+
+      - name: Generate README version matrix entry
+        run: .github/update-version-matrix.sh "${{ inputs.project-version }}" "${{ inputs.quarkus-version }}"
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request with updated matrix
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: update README version matrix"
+          title: "docs: update README version matrix"
+          body: |
+            Automated update of the README version matrix.
+
+            - Project version: `${{ inputs.project-version }}`
+            - Quarkus version: `${{ inputs.quarkus-version }}`
+
+            The workflow infers whether the release is `LTS` or `Normal` from the project version suffix.
+          branch: "automation/update-version-matrix-${{ inputs.project-version }}"
+          delete-branch: true
+          add-paths: |
+            README.md

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ You can learn more in [Quarkus OpenAPI Generator Documentation](http://docs.quar
 > [!TIP]
 > If you want to improve the docs, please feel free to contribute editing the docs in [Docs](https://github.com/quarkiverse/quarkus-openapi-generator/tree/main/docs/modules/ROOT). But first, read [this page](CONTRIBUTING.md).
 
+## Version Matrix
+
+<!-- VERSION-MATRIX:START -->
+The project keeps normal releases and `-lts` releases aligned with specific Quarkus LTS streams.
+
+| Project version | Type | Quarkus version |
+|---|---|---|
+| 2.17.0 | Normal | 3.34.5 |
+| 2.16.0 | Normal | 3.34.2 |
+| 2.15.0-lts | LTS | 3.33.1 |
+| 2.15.0 | Normal | 3.32.2 |
+| 2.14.0-lts | LTS | 3.27.2 |
+| 2.14.0 | Normal | 3.30.6 |
+| 2.13.0-lts | LTS | 3.20.3 |
+| 2.13.0 | Normal | 3.28.4 |
+| 2.12.1-lts | LTS | 3.20.2.2 |
+| 2.12.1 | Normal | 3.26.1 |
+
+<!-- VERSION-MATRIX:END -->
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):


### PR DESCRIPTION
This pull request introduces automation for maintaining a version matrix in the `README.md` that aligns project releases with their corresponding Quarkus versions. The main changes include adding a new workflow and script to update the matrix, as well as updating the `README.md` to display the version matrix.

**Automation for version matrix maintenance:**

* Added a new GitHub Actions workflow (`.github/workflows/update-version-matrix.yml`) that enables maintainers to update the version matrix in `README.md` via workflow dispatch. The workflow accepts project and Quarkus versions as inputs, runs a script to update the matrix, and automatically creates a pull request if changes are detected.
* Introduced a shell script (`.github/update-version-matrix.sh`) that validates input, parses and updates the version matrix section in `README.md`, and ensures correct sorting and formatting. The script uses an embedded Python script for robust parsing and updating.

**Documentation update:**

* Added a "Version Matrix" section to `README.md` that lists project versions, their type (Normal or LTS), and the associated Quarkus version. The section is delimited by markers for automated updates.