### PR TITLE
Reelase security patch version 2.11.1-lts

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.11.0-lts
-  next-version: 3.0.0-lts-SNAPSHOT
+  current-version: 2.11.1-lts
+  next-version: 2.11.2-lts-SNAPSHOT


### PR DESCRIPTION
Releasing an LTS version for the security vulnerability reported here: https://github.com/quarkiverse/quarkus-openapi-generator/security/advisories/GHSA-fr8f-rwjx-f32v
