### PR TITLE
Release 2.11.1-lts (Second Round)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,5 @@
 release:
   current-version: 2.11.1-lts
   next-version: 2.11.2-lts-SNAPSHOT
+
+  


### PR DESCRIPTION
Release 2.11.1-lts (Second round)

See:
- https://github.com/quarkiverse/quarkus-openapi-generator/pull/1586