### PR TITLE
refactor: remove unused model annotations and improve documentation clarity

### DIFF
--- a/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
@@ -1,4 +1,3 @@
-{@org.openapitools.codegen.CodegenModel m}
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 {#if m.description}

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server.adoc
@@ -304,7 +304,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Whether to skip generation if the generated sources are unchanged.
+Whether to skip generation when the persisted fingerprint of the OpenAPI specification and relevant generation configuration matches the previous run.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server_quarkus.openapi.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator-server_quarkus.openapi.adoc
@@ -304,7 +304,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Whether to skip generation if the generated sources are unchanged.
+Whether to skip generation when the persisted fingerprint of the OpenAPI specification and relevant generation configuration matches the previous run.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/server/deployment/src/main/resources/server-templates/libraries/microprofile/api.qute
+++ b/server/deployment/src/main/resources/server-templates/libraries/microprofile/api.qute
@@ -1,5 +1,3 @@
-{@java.lang.Boolean use-reactive}
-
 package {package};
 
 {#if use-bean-validation}

--- a/server/deployment/src/main/resources/server-templates/libraries/microprofile/pojo.qute
+++ b/server/deployment/src/main/resources/server-templates/libraries/microprofile/pojo.qute
@@ -1,6 +1,3 @@
-{@org.openapitools.codegen.CodegenModel m}
-{@java.lang.Boolean use-builders}
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 {#if m.description}


### PR DESCRIPTION
Fixes: #1636 

Qute annotations cause a build-time processor to generate `ValueResolver` classes that reference `CodegenDiscriminator$MappedModel`, a class belonging to OpenApiGenerator, a deployment dependency, not a runtime dependency. When Quarkus uses Qute simultaneously, as was the case with `langchain4j`which also uses Qute, it scans all templates in the classpath, finds them in pojo.qute, and generates resolvers. At runtime, this class does not exist in the classpath, causing a `ClassNotFoundException` error.

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

