### PR TITLE
OpenAPI client generator incorrectly using response wrapper classes instead of schema classes

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusCodegenConfigurator.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusCodegenConfigurator.java
@@ -10,6 +10,7 @@ public class QuarkusCodegenConfigurator extends CodegenConfigurator {
         this.setGeneratorName("quarkus");
         this.setTemplatingEngineName("qute");
         this.setLibrary(JavaClientCodegen.MICROPROFILE);
+        this.addInlineSchemaOption("SKIP_SCHEMA_REUSE", "true");
     }
 
 }

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -930,6 +930,31 @@ public class OpenApiClientGeneratorWrapperTest {
     }
 
     @Test
+    void verifyIssue1431SchemaReferenceNotReplacedByResponseWrapper() throws URISyntaxException, FileNotFoundException {
+        OpenApiClientGeneratorWrapper generatorWrapper = createGeneratorWrapper("issue-1431.yaml");
+        final List<File> generatedFiles = generatorWrapper.generate("org.issue1431");
+
+        assertNotNull(generatedFiles);
+        assertFalse(generatedFiles.isEmpty());
+
+        final Optional<File> fruitPagedResultFile = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("FruitPagedResult.java")).findFirst();
+        assertThat(fruitPagedResultFile).isPresent();
+
+        final CompilationUnit cu = StaticJavaParser.parse(fruitPagedResultFile.orElseThrow());
+        List<FieldDeclaration> fields = cu.findAll(FieldDeclaration.class);
+
+        Optional<VariableDeclarator> listField = findVariableByName(fields, "_list");
+        assertThat(listField).isPresent();
+
+        String listFieldType = listField.orElseThrow().getType().asString();
+        assertTrue(listFieldType.contains("Fruit"),
+                "FruitPagedResult._list should reference Fruit, but got: " + listFieldType);
+        assertFalse(listFieldType.contains("CreateFruit201Response"),
+                "FruitPagedResult._list should NOT reference CreateFruit201Response, but got: " + listFieldType);
+    }
+
+    @Test
     void verifyXClassExtraAnnotationGeneration() throws URISyntaxException, FileNotFoundException {
         final List<File> generatedFiles = createGeneratorWrapper("x-class-extra-annotation-openapi.json")
                 .generate("org.classExtraAnnotation");

--- a/client/deployment/src/test/resources/openapi/issue-1431.yaml
+++ b/client/deployment/src/test/resources/openapi/issue-1431.yaml
@@ -1,0 +1,109 @@
+openapi: 3.1.0
+info:
+  title: Fruits API - Bug Reproduction
+  version: 1.0.0
+  description: Minimal reproduction case for OpenAPI generator bug where response wrapper classes are incorrectly used in component schema references
+paths:
+  /api/fruits:
+    get:
+      summary: List fruits
+      description: Retrieves a paginated list of fruits
+      operationId: getFruits
+      tags:
+        - fruits
+      parameters:
+        - description: Page number (0-based)
+          name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - description: Number of items per page
+          name: size
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 20
+      responses:
+        "200":
+          description: Successfully retrieved fruits
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FruitPagedResult"
+    post:
+      summary: Create fruit
+      description: Creates a new fruit
+      operationId: createFruit
+      tags:
+        - fruits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewFruit"
+        required: true
+      responses:
+        "201":
+          description: Fruit created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Fruit"
+components:
+  schemas:
+    Fruit:
+      type: object
+      required:
+        - name
+        - color
+      description: Fruit information
+      properties:
+        name:
+          type: string
+          description: Fruit name
+        color:
+          type: string
+          description: Fruit color
+    FruitPagedResult:
+      type: object
+      required:
+        - pageIndex
+        - size
+        - totalCount
+        - list
+      description: Paginated result containing fruits
+      properties:
+        pageIndex:
+          type: integer
+          format: int64
+          description: Current page index (0-based)
+          minimum: 0
+        size:
+          type: integer
+          format: int64
+          description: Number of items per page
+        totalCount:
+          type: integer
+          format: int64
+          description: Total number of items across all pages
+        list:
+          type: array
+          items:
+            $ref: "#/components/schemas/Fruit"
+          description: List of items on the current page
+    NewFruit:
+      type: object
+      required:
+        - name
+        - color
+      description: Request payload for creating a new fruit
+      properties:
+        name:
+          type: string
+          description: Fruit name
+        color:
+          type: string
+          description: Fruit color


### PR DESCRIPTION
Fixes: #1431 

https://openapi-generator.tech/docs/customization/#inline-schema-naming

The [Problem](https://github.com/gunnarpruefer/openapi-client-generator-schema-reference-bug/blob/main/src/main/openapi/openapi.yml) was happening

When an OpenAPI specification defines a component schema (e.g., `Fruit`) , Since it is referenced both in a response (`$ref: '#/components/schemas/Fruit'`) and in a property of another schema (e.g., `FruitPagedResult.list`), the generated code incorrectly uses the name of the response wrapper class instead of the original schema class.

The `InlineModelResolver.flatten()` method of openapi-generator processes paths before components. When it finds the response `201` with `$ref: Fruit`, it creates a schema wrapper (`createFruit_201_response`) in the components. Subsequently, when flattening the component schemas, the `matchGenerated()` method compares schemas for JSON structural equality. Since `createFruit_201_response` and `Fruit` have identical structures, `matchGenerated()` considers them equal and rewrites the `$ref` in `FruitPagedResult.list` to point to `createFruit_201_response` instead of `Fruit`.




 - [X] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket