### PR TITLE
feat: implement CustomCredentialsProvider with alternative and priority annotations, add metadata test

### DIFF
--- a/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
+++ b/client/integration-tests/override-credential-provider/src/main/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProvider.java
@@ -2,7 +2,9 @@ package io.quarkiverse.openapi.generator.it.creds;
 
 import java.util.Optional;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,10 +13,15 @@ import io.quarkiverse.openapi.generator.providers.ConfigCredentialsProvider;
 import io.quarkiverse.openapi.generator.providers.CredentialsContext;
 
 @Dependent
+@Alternative
+@Priority(200)
 public class CustomCredentialsProvider extends ConfigCredentialsProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomCredentialsProvider.class);
 
     public static String TOKEN = "FIXED_TEST_TOKEN";
+
+    public CustomCredentialsProvider() {
+    }
 
     @Override
     public Optional<String> getBearerToken(CredentialsContext input) {

--- a/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderMetadataTest.java
+++ b/client/integration-tests/override-credential-provider/src/test/java/io/quarkiverse/openapi/generator/it/creds/CustomCredentialsProviderMetadataTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.openapi.generator.it.creds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+import org.junit.jupiter.api.Test;
+
+class CustomCredentialsProviderMetadataTest {
+
+    @Test
+    void shouldBeDeclaredAsAnAlternativeOverride() throws Exception {
+        assertThat(CustomCredentialsProvider.class.isAnnotationPresent(Dependent.class)).isTrue();
+        assertThat(CustomCredentialsProvider.class.isAnnotationPresent(Alternative.class)).isTrue();
+
+        Priority priority = CustomCredentialsProvider.class.getAnnotation(Priority.class);
+        assertThat(priority).isNotNull();
+        assertThat(priority.value()).isEqualTo(200);
+
+        Constructor<CustomCredentialsProvider> constructor = CustomCredentialsProvider.class.getDeclaredConstructor();
+        assertThat(Modifier.isPublic(constructor.getModifiers())).isTrue();
+    }
+}


### PR DESCRIPTION
Fixes: #1660

The build process breaks later, in the final `quarkus:build` step, when Quarkus' Arc attempts to generate the beans.

I'll compare it to the similar working module, `client/integration-tests/auth-provider/src/main/java/io/quarkiverse/openapi/generator/it/auth/provider/CustomCredentialsProvider.java`  the most suspicious difference is that the one that passes has an explicit constructor `public CustomCredentialsProvider() {}`, while the one that fails does not.


- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket