### PR TITLE
feat: implement composite authentication provider

### DIFF
--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
@@ -3,8 +3,10 @@ package io.quarkiverse.openapi.generator.providers;
 import static io.quarkiverse.openapi.generator.providers.AbstractAuthenticationPropagationHeadersFactory.propagationHeaderNamePrefix;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.ws.rs.client.ClientRequestContext;
@@ -31,16 +33,66 @@ public class BaseCompositeAuthenticationProvider implements ClientRequestFilter 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         Set<String> removableHeaderPrefix = new HashSet<>();
+        List<Exception> exceptionsDuringFilter = new ArrayList<>();
+        boolean applied = false;
+
         for (AuthProvider authProvider : authProviders) {
             if (authProvider instanceof AbstractAuthProvider) {
                 removableHeaderPrefix
                         .add(propagationHeaderNamePrefix(((AbstractAuthProvider) authProvider).getOpenApiSpecId()));
             }
             if (canFilter(authProvider, requestContext)) {
-                authProvider.filter(requestContext);
+                Optional<Exception> possibleException = tryFilter(authProvider, requestContext);
+                if (possibleException.isEmpty()) {
+                    applied = true;
+                    break;
+                }
+                exceptionsDuringFilter.add(possibleException.get());
             }
         }
+
+        if (!applied) {
+            throwExceptionFrom(exceptionsDuringFilter);
+        }
+
         removeAuthenticationTemporalHeaders(requestContext, removableHeaderPrefix);
+    }
+
+    /**
+     * Tries to apply the filter of the given provider.
+     * As per the OpenAPI spec, only one security requirement needs to be satisfied.
+     * See <a href="https://spec.openapis.org/oas/v3.1.0#security-requirement-object">Security Requirement Object</a>:
+     * "A declaration of security schemes which can be used for the API operation.
+     * The list of values includes alternative security requirement objects that can be used.
+     * Only one of the security requirement objects need to be satisfied to authorize a request."
+     * Thus, if one provider successfully applied, we stop trying others for this request.
+     *
+     * @return an empty {@link Optional} if the filter was applied successfully,
+     *         or an {@link Optional} containing the exception if the provider failed.
+     */
+    private Optional<Exception> tryFilter(AuthProvider authProvider, ClientRequestContext requestContext) {
+        try {
+            authProvider.filter(requestContext);
+            return Optional.empty();
+        } catch (Exception e) {
+            return Optional.of(e);
+        }
+    }
+
+    private static void throwExceptionFrom(List<Exception> exceptionsDuringFilter) throws IOException {
+        if (exceptionsDuringFilter.isEmpty()) {
+            return;
+        }
+
+        // If none of the alternative providers could be applied, re-throw the last exception.
+        Exception lastException = exceptionsDuringFilter.get(exceptionsDuringFilter.size() - 1);
+        if (lastException instanceof IOException) {
+            throw (IOException) lastException;
+        } else if (lastException instanceof RuntimeException) {
+            throw (RuntimeException) lastException;
+        } else {
+            throw new RuntimeException(lastException);
+        }
     }
 
     /**

--- a/client/runtime/src/test/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProviderTest.java
+++ b/client/runtime/src/test/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProviderTest.java
@@ -1,0 +1,280 @@
+package io.quarkiverse.openapi.generator.providers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test for BaseCompositeAuthenticationProvider to validate that when multiple
+ * alternative security schemes are defined for an operation (OR requirement),
+ * only one provider needs to be satisfied.
+ */
+public class BaseCompositeAuthenticationProviderTest {
+
+    private OperationAuthInfo createOperation() {
+        return OperationAuthInfo.builder()
+                .withId("testOp")
+                .withMethod("POST")
+                .withPath("/api/test")
+                .build();
+    }
+
+    private OperationAuthInfo createOtherOperation() {
+        return OperationAuthInfo.builder()
+                .withId("otherOp")
+                .withMethod("GET")
+                .withPath("/api/other")
+                .build();
+    }
+
+    private ClientRequestContext createRequestContext(String method, String path) {
+        ClientRequestContext requestContext = Mockito.mock(ClientRequestContext.class);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(requestContext.getHeaders()).thenReturn(headers);
+        when(requestContext.getMethod()).thenReturn(method);
+        when(requestContext.getUri()).thenReturn(URI.create("http://localhost" + path));
+        return requestContext;
+    }
+
+    //region Provider setup helpers
+
+    /**
+     * Configures a mock provider to add an Authorization header when its filter method is called,
+     * simulating a successful authentication.
+     */
+    private void givenProviderWillAuthenticate(AuthProvider provider, MultivaluedMap<String, Object> headers, String token) {
+        try {
+            Mockito.doAnswer(inv -> {
+                headers.putSingle("Authorization", token);
+                return null;
+            }).when(provider).filter(any(ClientRequestContext.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Configures a mock provider to throw an exception when its filter method is called.
+     */
+    private void givenProviderWillFail(AuthProvider provider, RuntimeException exception) {
+        try {
+            Mockito.doThrow(exception).when(provider).filter(any(ClientRequestContext.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Configures a mock provider to throw an IOException when its filter method is called.
+     */
+    private void givenProviderWillFail(AuthProvider provider, IOException exception) {
+        try {
+            Mockito.doAnswer(inv -> {
+                throw exception;
+            }).when(provider).filter(any(ClientRequestContext.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //endregion
+
+    //region Exception assertion helpers
+
+    /**
+     * Asserts that calling the composite filter throws an exception with the expected message.
+     */
+    private void assertFilterThrows(BaseCompositeAuthenticationProvider composite,
+            ClientRequestContext requestContext, String expectedMessage) throws IOException {
+        Exception thrown = assertThrows(Exception.class, () -> composite.filter(requestContext));
+        assertEquals(expectedMessage, thrown.getMessage());
+    }
+
+    //endregion
+
+    @Test
+    void testOnlyOneAlternativeProviderIsCalled() throws IOException {
+        // Create two providers that both apply to the same operation
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        // Both providers apply to the operation
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+
+        // Mock the request context
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        // Set up provider1 to add an Authorization header (simulating successful auth)
+        givenProviderWillAuthenticate(provider1, headers, "Bearer token1");
+
+        // Create the composite provider
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider1, provider2));
+
+        // Apply the filter
+        composite.filter(requestContext);
+
+        // Verify that provider1 was called once
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+
+        // Verify that provider2 was NOT called because provider1 already applied successfully
+        verify(provider2, never()).filter(any(ClientRequestContext.class));
+
+        // Verify that the Authorization header was set by provider1
+        assertEquals("Bearer token1", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void testBothProvidersAreCalledWhenFirstFails() throws IOException {
+        // Create two providers that both apply to the same operation
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        // Both providers apply to the operation
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+
+        // Mock the request context
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        // Set up provider1 to throw an exception (simulating missing configuration)
+        givenProviderWillFail(provider1, new RuntimeException("Missing OAuth2 configuration"));
+        givenProviderWillAuthenticate(provider2, headers, "Bearer token2");
+
+        // Create the composite provider
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider1, provider2));
+
+        // Apply the filter
+        composite.filter(requestContext);
+
+        // Verify that provider1 was called once
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+
+        // Verify that provider2 was called because provider1 threw an exception
+        verify(provider2, times(1)).filter(any(ClientRequestContext.class));
+
+        // Verify that the Authorization header was set by provider2
+        assertEquals("Bearer token2", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void testOnlyRelevantProviderIsCalled() throws IOException {
+        // Create two providers that apply to different operations
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        // Provider1 applies to /api/test, provider2 applies to /api/other
+        OperationAuthInfo operation1 = createOperation();
+        OperationAuthInfo operation2 = createOtherOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation1));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation2));
+
+        // Mock the request context for /api/test
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        givenProviderWillAuthenticate(provider1, headers, "Bearer token1");
+
+        // Create the composite provider
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider1, provider2));
+
+        // Apply the filter
+        composite.filter(requestContext);
+
+        // Verify that provider1 was called
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+
+        // Verify that provider2 was NOT called because it doesn't apply to this operation
+        verify(provider2, never()).filter(any(ClientRequestContext.class));
+
+        // Verify that the Authorization header was set by provider1
+        assertEquals("Bearer token1", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void testStopsOnFirstSuccessfulProvider() throws IOException {
+        // Create three providers for the same operation
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider3 = Mockito.mock(AuthProvider.class);
+
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider3.operationsToFilter()).thenReturn(List.of(operation));
+
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        // All providers succeed, but only the first should be called
+        givenProviderWillAuthenticate(provider1, headers, "Bearer token1");
+
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(
+                List.of(provider1, provider2, provider3));
+
+        composite.filter(requestContext);
+
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+        verify(provider2, never()).filter(any(ClientRequestContext.class));
+        verify(provider3, never()).filter(any(ClientRequestContext.class));
+        assertEquals("Bearer token1", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void testAllProvidersFail() throws IOException {
+        // Create two providers that both fail
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+
+        // Both providers throw exceptions
+        givenProviderWillFail(provider1, new RuntimeException("First provider failed"));
+        givenProviderWillFail(provider2, new RuntimeException("Second provider failed"));
+
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider1, provider2));
+
+        assertFilterThrows(composite, requestContext, "Second provider failed");
+
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+        verify(provider2, times(1)).filter(any(ClientRequestContext.class));
+    }
+
+    @Test
+    void testIOExceptionIsReThrown() throws IOException {
+        AuthProvider provider = Mockito.mock(AuthProvider.class);
+        OperationAuthInfo operation = createOperation();
+        when(provider.operationsToFilter()).thenReturn(List.of(operation));
+
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test");
+
+        givenProviderWillFail(provider, new IOException("Network error"));
+
+        BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider));
+
+        assertFilterThrows(composite, requestContext, "Network error");
+    }
+}


### PR DESCRIPTION
Fixes: #430 

Since the specification accepts multiple security alternatives, either `BasicAuth` or `OAuth2`, if a provider of that class did not have the settings applied, it would throw an exception, even if the alternative provider, such as `BasicAuthenticationProvider`, was configured.

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket