### PR TITLE
feat: Support useOneOfInterfaces feature in client generator 

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -95,7 +95,8 @@ public interface CodegenConfig extends GlobalCodegenConfig {
         METHOD_PER_MEDIA_TYPE("method-per-media-type"),
         PREFERRED_CONTENT_TYPE("preferred-content-type"),
         NAME_MAPPINGS("name-mappings"),
-        RESTEASY_REACTIVE_CLIENT_FORM("resteasy-reactive-client-form");
+        RESTEASY_REACTIVE_CLIENT_FORM("resteasy-reactive-client-form"),
+        USE_ONE_OF_INTERFACES("use-one-of-interfaces");
 
         private final String name;
 

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
@@ -240,4 +240,11 @@ public interface CommonItemConfig {
      */
     @WithName("preferred-content-type")
     Optional<String> preferredContentType();
+
+    /**
+     * Generate interfaces for {@code oneOf} schemas and have their members implement those interfaces,
+     * instead of generating a class with all the fields of the members
+     */
+    @WithName("use-one-of-interfaces")
+    Optional<Boolean> useOneOfInterfaces();
 }

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -381,6 +381,9 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
         getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.NORMALIZER, String.class, String.class)
                 .ifPresent(generator::withOpenApiNormalizer);
 
+        getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.USE_ONE_OF_INTERFACES, Boolean.class)
+                .ifPresent(generator::withUseOneOfInterfaces);
+
         Boolean additionalPropertiesAsAttribute = getValues(smallRyeConfig, openApiFilePath,
                 CodegenConfig.ConfigName.ADDITIONAL_PROPERTIES_AS_ATTRIBUTE, Boolean.class)
                 .orElse(Boolean.FALSE);

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapter.java
@@ -25,6 +25,7 @@ public class QuteTemplatingEngineAdapter extends AbstractTemplatingEngineAdapter
             "bodyParams.qute",
             "enumClass.qute",
             "enumOuterClass.qute",
+            "oneOfInterface.qute",
             "headerParams.qute",
             "pathParams.qute",
             "cookieParams.qute",

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -8,6 +8,7 @@ import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.requireNonNull;
 import static org.openapitools.codegen.languages.AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS;
+import static org.openapitools.codegen.languages.AbstractJavaCodegen.USE_ONE_OF_INTERFACES;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -232,6 +233,11 @@ public abstract class OpenApiClientGeneratorWrapper {
 
     public OpenApiClientGeneratorWrapper withOpenApiNormalizer(final Map<String, String> openApiNormalizer) {
         configurator.setOpenapiNormalizer(openApiNormalizer);
+        return this;
+    }
+
+    public OpenApiClientGeneratorWrapper withUseOneOfInterfaces(final Boolean useOneOfInterfaces) {
+        this.configurator.addAdditionalProperty(USE_ONE_OF_INTERFACES, useOneOfInterfaces);
         return this;
     }
 

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/model.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/model.qute
@@ -18,5 +18,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 {#for m in models}
 {#if m.model.isEnum}{#include enumOuterClass.qute e=m.model/}
-{#else}{#include pojo.qute m=m.model codegen=classes-codegen package=modelPackage/}{/if}
+{#else}{#if m.model.vendorExtensions.x-is-one-of-interface.or(false)}{#include oneOfInterface.qute m=m.model/}
+{#else}{#include pojo.qute m=m.model codegen=classes-codegen package=modelPackage/}{/if}{/if}
 {/for}

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/oneOfInterface.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/oneOfInterface.qute
@@ -1,0 +1,8 @@
+{@org.openapitools.codegen.CodegenModel m}
+@com.fasterxml.jackson.annotation.JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.DEDUCTION)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+{#for sub in m.interfaces}
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type({sub}.class),
+{/for}})
+public interface {m.classname} {
+}

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 {#if m.vendorExtensions.containsKey('x-class-extra-annotation')}
 {m.vendorExtensions['x-class-extra-annotation']}
 {/if}
-public class {m.classname} {#if m.parent}extends {m.parent}{/if}{#if serializableModel} implements java.io.Serializable{/if} {
+{#let xImpl=m.vendorExtensions.x-implements.or(false)}public class {m.classname} {#if m.parent}extends {m.parent}{/if}{#if xImpl} implements {#for iface in xImpl}{iface}{#if iface_hasNext}, {/if}{/for}{/if}{/let} {
 
     {#for v in m.vars}
     {#if !v.deprecated || openapi:genDeprecatedModelAttr(package, m.classname, codegen)}

--- a/client/integration-tests/pom.xml
+++ b/client/integration-tests/pom.xml
@@ -52,6 +52,7 @@
     <module>without-oidc</module>
     <module>serializable-model</module>
     <module>equals-hashcode</module>
+    <module>use-one-of-interfaces</module>
     <module>override-credential-provider</module>
     <module>jsonproperty-getter-and-setter</module>
     <module>suppress-warnings</module>

--- a/client/integration-tests/use-one-of-interfaces/pom.xml
+++ b/client/integration-tests/use-one-of-interfaces/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-openapi-generator-integration-tests</artifactId>
+        <groupId>io.quarkiverse.openapi.generator</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-openapi-generator-it-use-one-of-interfaces</artifactId>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - UseOneOfInterfaces</name>
+    <description>Example project for general usage</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.openapi.generator</groupId>
+            <artifactId>quarkus-openapi-generator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager
+                                        </java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/client/integration-tests/use-one-of-interfaces/src/main/openapi/use-one-of-interfaces.yaml
+++ b/client/integration-tests/use-one-of-interfaces/src/main/openapi/use-one-of-interfaces.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: NoUseOneOfInterfaces - OpenAPI 3.0
+  version: 1.0.0
+servers:
+  - url: /api/v1
+paths:
+  /things/{id}:
+    get:
+      operationId: getThingById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Holder"
+components:
+  schemas:
+    SomeThing:
+      type: object
+      properties:
+        some:
+          type: string
+    OtherThing:
+      type: object
+      properties:
+        other:
+          type: string
+    Holder:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        thing:
+          oneOf:
+            - $ref: '#/components/schemas/SomeThing'
+            - $ref: '#/components/schemas/OtherThing'
+

--- a/client/integration-tests/use-one-of-interfaces/src/main/resources/application.properties
+++ b/client/integration-tests/use-one-of-interfaces/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.openapi-generator.codegen.spec.use_one_of_interfaces_yaml.base-package=org.acme.one.of.interfaces
+quarkus.openapi-generator.codegen.spec.use_one_of_interfaces_yaml.use-one-of-interfaces=true

--- a/client/integration-tests/use-one-of-interfaces/src/test/java/io/quarkiverse/openapi/generator/it/UseOneOfInterfacesTest.java
+++ b/client/integration-tests/use-one-of-interfaces/src/test/java/io/quarkiverse/openapi/generator/it/UseOneOfInterfacesTest.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.openapi.generator.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.acme.one.of.interfaces.model.OtherThing;
+import org.acme.one.of.interfaces.model.SomeThing;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class UseOneOfInterfacesTest {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Test
+    void oneOfPropertyIsInterface() {
+        assertThat(org.acme.one.of.interfaces.model.HolderThing.class.isInterface()).isTrue();
+    }
+
+    @Test
+    void oneOfMembersImplementInterface() {
+        assertThat(org.acme.one.of.interfaces.model.HolderThing.class)
+                .isAssignableFrom(org.acme.one.of.interfaces.model.SomeThing.class);
+        assertThat(org.acme.one.of.interfaces.model.HolderThing.class)
+                .isAssignableFrom(org.acme.one.of.interfaces.model.OtherThing.class);
+    }
+
+    @Test
+    void someThingSerializes() throws JsonProcessingException {
+        var thing = new SomeThing()
+                .some("hello");
+
+        var json = mapper.writeValueAsString(thing);
+
+        assertThat(json).isEqualTo("{\"some\":\"hello\"}");
+    }
+
+    @Test
+    void otherThingDeserializes() throws JsonProcessingException {
+        var thing = new OtherThing()
+                .other("world");
+
+        var json = mapper.writeValueAsString(thing);
+
+        assertThat(json).isEqualTo("{\"other\":\"world\"}");
+    }
+
+    @Test
+    void holderWithOtherThingSerializes() throws JsonProcessingException {
+        var thing = new org.acme.one.of.interfaces.model.Holder()
+                .id(1L)
+                .thing(new OtherThing()
+                        .other("world"));
+
+        var json = mapper.writeValueAsString(thing);
+
+        assertThat(json).isEqualTo("{\"id\":1,\"thing\":{\"other\":\"world\"}}");
+    }
+
+    @Test
+    void holderWithSomeThingDeserializes() throws JsonProcessingException {
+        var json = "{\"id\":1,\"thing\":{\"some\":\"hello\"}}";
+
+        var holder = mapper.readValue(json, org.acme.one.of.interfaces.model.Holder.class);
+
+        assertThat(holder.getId()).isEqualTo(1L);
+        assertThat(holder.getThing())
+                .asInstanceOf(InstanceOfAssertFactories.type(SomeThing.class))
+                .extracting(SomeThing::getSome)
+                .isEqualTo("hello");
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
@@ -582,6 +582,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-use-one-of-interfaces]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-use-one-of-interfaces[`+++quarkus.openapi-generator.codegen.use-one-of-interfaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.use-one-of-interfaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Generate interfaces for `oneOf` schemas and have their members implement those interfaces, instead of generating a class with all the fields of the members
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_USE_ONE_OF_INTERFACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_USE_ONE_OF_INTERFACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-verbose]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-verbose[`+++quarkus.openapi-generator.codegen.verbose+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi-generator.codegen.verbose+++[]
@@ -1410,6 +1431,27 @@ Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__PRE
 endif::add-copy-button-to-env-var[]
 --
 |string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-use-one-of-interfaces]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-use-one-of-interfaces[`+++quarkus.openapi-generator.codegen.spec."spec-item".use-one-of-interfaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.spec."spec-item".use-one-of-interfaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Generate interfaces for `oneOf` schemas and have their members implement those interfaces, instead of generating a class with all the fields of the members
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__USE_ONE_OF_INTERFACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__USE_ONE_OF_INTERFACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-base-package]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-base-package[`+++quarkus.openapi-generator.codegen.spec."spec-item".base-package+++`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
@@ -582,6 +582,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-use-one-of-interfaces]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-use-one-of-interfaces[`+++quarkus.openapi-generator.codegen.use-one-of-interfaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.use-one-of-interfaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Generate interfaces for `oneOf` schemas and have their members implement those interfaces, instead of generating a class with all the fields of the members
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_USE_ONE_OF_INTERFACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_USE_ONE_OF_INTERFACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-verbose]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-verbose[`+++quarkus.openapi-generator.codegen.verbose+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi-generator.codegen.verbose+++[]
@@ -1431,6 +1452,27 @@ Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__PRE
 endif::add-copy-button-to-env-var[]
 --
 |string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-use-one-of-interfaces]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-use-one-of-interfaces[`+++quarkus.openapi-generator.codegen.spec."spec-item".use-one-of-interfaces+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.spec."spec-item".use-one-of-interfaces+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Generate interfaces for `oneOf` schemas and have their members implement those interfaces, instead of generating a class with all the fields of the members
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__USE_ONE_OF_INTERFACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__USE_ONE_OF_INTERFACES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-base-package]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-base-package[`+++quarkus.openapi-generator.codegen.spec."spec-item".base-package+++`]##


### PR DESCRIPTION
Closes #1680

This PR exposes the useOneOfInterfaces feature and extends the templates accordingly.  
Because the implemented interface is in `vendorExtensions.x-implements`, which also contains Serializable when serializableModel is true, we no longer need `{#if serializableModel} implements java.io.Serializable{/if}` in `pojo.qute`. This is also matches the way it is implemented in the upstream java templates

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [x] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-quarkus2` to backport the original PR to the `quarkus2` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
