### PR TITLE
fix: prevent duplicate codegen execution with multiple source roots #1708

### DIFF
--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/apicurio/ApicurioOpenApiServerCodegen.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/apicurio/ApicurioOpenApiServerCodegen.java
@@ -55,8 +55,9 @@ public class ApicurioOpenApiServerCodegen implements CodeGenProvider {
     @Override
     public boolean shouldRun(Path sourceDir, Config config) {
 
-        if (sourceDir.endsWith(Path.of("src", "test", this.inputDirectory()))) {
-            // skip when generate-code-tests
+        // Only run for the main source directory to prevent multiple executions
+        // when the project has multiple source roots
+        if (!sourceDir.endsWith(Path.of("src", "main", this.inputDirectory()))) {
             return false;
         }
 

--- a/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/openapitools/OpenAPIToolsServerCodegen.java
+++ b/server/deployment/src/main/java/io/quarkiverse/openapi/server/generator/deployment/codegen/openapitools/OpenAPIToolsServerCodegen.java
@@ -72,8 +72,9 @@ public class OpenAPIToolsServerCodegen implements CodeGenProvider {
     @Override
     public boolean shouldRun(Path sourceDir, Config config) {
 
-        if (sourceDir.endsWith(Path.of("src", "test", this.inputDirectory()))) {
-            // skip when generate-code-tests
+        // Only run for the main source directory to prevent multiple executions
+        // when the project has multiple source roots
+        if (!sourceDir.endsWith(Path.of("src", "main", this.inputDirectory()))) {
             return false;
         }
 

--- a/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/ApicurioOpenApiServerCodegenShouldRunTest.java
+++ b/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/ApicurioOpenApiServerCodegenShouldRunTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.openapi.server.generator.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.openapi.server.generator.deployment.codegen.apicurio.ApicurioOpenApiServerCodegen;
+
+class ApicurioOpenApiServerCodegenShouldRunTest {
+
+    private final ApicurioOpenApiServerCodegen codegen = new ApicurioOpenApiServerCodegen();
+
+    @Test
+    void shouldRunForMainResourcesDirectory() {
+        Config config = MockConfigUtils.getTestConfig("apicurio-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "main", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isTrue();
+    }
+
+    @Test
+    void shouldNotRunForTestResourcesDirectory() {
+        Config config = MockConfigUtils.getTestConfig("apicurio-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "test", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+
+    @Test
+    void shouldNotRunForAdditionalSourceRoot() {
+        Config config = MockConfigUtils.getTestConfig("apicurio-multispec.application.properties");
+        Path sourceDir = Path.of("project", "target", "generated-sources", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+
+    @Test
+    void shouldNotRunForCustomSourceRoot() {
+        Config config = MockConfigUtils.getTestConfig("apicurio-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "generated", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+}

--- a/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/OpenAPIToolsServerCodegenShouldRunTest.java
+++ b/server/deployment/src/test/java/io/quarkiverse/openapi/server/generator/deployment/OpenAPIToolsServerCodegenShouldRunTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.openapi.server.generator.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.openapi.server.generator.deployment.codegen.openapitools.OpenAPIToolsServerCodegen;
+
+class OpenAPIToolsServerCodegenShouldRunTest {
+
+    private final OpenAPIToolsServerCodegen codegen = new OpenAPIToolsServerCodegen();
+
+    @Test
+    void shouldRunForMainResourcesDirectory() {
+        Config config = MockConfigUtils.getTestConfig("openapitools-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "main", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isTrue();
+    }
+
+    @Test
+    void shouldNotRunForTestResourcesDirectory() {
+        Config config = MockConfigUtils.getTestConfig("openapitools-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "test", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+
+    @Test
+    void shouldNotRunForAdditionalSourceRoot() {
+        Config config = MockConfigUtils.getTestConfig("openapitools-multispec.application.properties");
+        Path sourceDir = Path.of("project", "target", "generated-sources", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+
+    @Test
+    void shouldNotRunForCustomSourceRoot() {
+        Config config = MockConfigUtils.getTestConfig("openapitools-multispec.application.properties");
+        Path sourceDir = Path.of("project", "src", "generated", "resources");
+
+        assertThat(codegen.shouldRun(sourceDir, config)).isFalse();
+    }
+}


### PR DESCRIPTION
Replace negative test-directory check with positive main-directory check in shouldRun() of both server codegens. Previously, when explicit config was present, the generator ran for every source root (test, custom, etc.) causing duplicate classes and build failures.

Now only src/main/resources triggers code generation.

see https://github.com/quarkiverse/quarkus-openapi-generator/issues/1708


Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ x ] You have read the [contributors guide](CONTRIBUTING.md)
- [ x ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ x ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ x ] Pull Request contains link to the issue
- [ x ] Pull Request contains link to any dependent or related Pull Request
- [ x ] Pull Request contains description of the issue
- [ x ] Pull Request does not include fixes for issues other than the main ticket
