### PR TITLE
docs: simplify version handling in documentation

### DIFF
--- a/docs/modules/ROOT/pages/includes/getting-started.adoc
+++ b/docs/modules/ROOT/pages/includes/getting-started.adoc
@@ -8,7 +8,7 @@ WARNING: Version 2.x.x of this extension supports Quarkus 3, and version 1.x.x s
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>{project-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/includes/server-apicurio-getting-started.adoc
+++ b/docs/modules/ROOT/pages/includes/server-apicurio-getting-started.adoc
@@ -5,7 +5,7 @@ Add the following dependency to your project's `pom.xml` file:
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-server</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>{project-version}</version>
 </dependency>
 ----
 
@@ -18,8 +18,6 @@ By default, the generated resources are annotated with Microprofile OpenAPI anno
     <artifactId>quarkus-smallrye-openapi</artifactId>
 </dependency>
 ----
-
-Note that since this extension has not been yet released, you'll need a local build of the dependency.
 
 You will also need to add or update the `quarkus-maven-plugin` configuration with the following:
 

--- a/docs/modules/ROOT/pages/openapitools.adoc
+++ b/docs/modules/ROOT/pages/openapitools.adoc
@@ -14,11 +14,9 @@ Add the following dependency to your project's `pom.xml` file:
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-server</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>{project-version}</version>
 </dependency>
 ----
-
-Note that since this extension has not been yet released, you'll need a local build of the dependency.
 
 You will also need to add or update the `quarkus-maven-plugin` configuration with the following:
 


### PR DESCRIPTION
Fixes: #1286 

There have likely been updates regarding this issue, but there was misleading information: snapshots are published remotely. The tutorials are using version `3.0.0-snapshot`. I made a small correction to the documentation with an updated project.

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
