### PR TITLE
fix: correct wording in documentation for Apicurio usage

### DIFF
--- a/docs/modules/ROOT/pages/openapitools.adoc
+++ b/docs/modules/ROOT/pages/openapitools.adoc
@@ -3,7 +3,7 @@
 include::./includes/attributes.adoc[]
 
 This documentation helps you to use Quarkus OpenAPI Generator Server with the OpenAPITools code generator.
-To see how to use with OpenAPITools, please see the xref:apicurio.adoc[Apicurio] documentation.
+To see how to use with Apicurio, please see the xref:apicurio.adoc[Apicurio] documentation.
 
 :extension-status: preview
 


### PR DESCRIPTION
a small error in the documentation
