### PR TITLE
test: cover anonymous security markers

### DIFF
--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -107,6 +107,16 @@ public class OpenApiClientGeneratorWrapperTest {
 
         // Assert that there's exactly one annotation with name=oauth
         assertThat(oauthAnnotationsCount).isEqualTo(1);
+
+        final Optional<File> apiFile = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("DefaultApi.java")).findFirst();
+        assertThat(apiFile).isPresent();
+
+        final String apiFileContent = StaticJavaParser.parse(apiFile.orElseThrow()).toString();
+        assertTrue(apiFileContent.contains("OperationMarker(name = \"client_id\""));
+        assertTrue(apiFileContent.contains("OperationMarker(name = \"oauth\""));
+        assertTrue(apiFileContent.contains("OperationMarker(name = \"bearerAuth\""));
+        assertFalse(apiFileContent.contains("OperationMarker(name = \"\""));
     }
 
     /**

--- a/client/deployment/src/test/resources/openapi/issue-933-security.yaml
+++ b/client/deployment/src/test/resources/openapi/issue-933-security.yaml
@@ -7,6 +7,7 @@ paths:
     post:
       operationId: doOperation
       security:
+        - {}
         - client_id: [ ]
         - oauth: [ read, write ]
         - bearerAuth: [ ]


### PR DESCRIPTION
Description
This adds coverage for OpenAPI operations that allow anonymous access with `{}` while also listing named security schemes. The test keeps the existing duplicate OAuth marker check and verifies generated operation markers only use the named schemes.

Issue
No issue was opened.

Related PR
None.

Validation
- `git diff --check`
- Targeted Maven test not run: `mvn` is unavailable locally.

Checklist
- [x] I have read the contributors guide.
- [ ] Code style check not run locally because Maven is unavailable.
- [x] Target branch is main.
- [ ] No issue link because no issue was opened.
- [x] No dependent or related PR.
- [x] Pull Request describes the issue.
- [x] Pull Request only updates anonymous security coverage.