### PR TITLE
feat: add support for reusing top-level enum schemas across API definitions

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -98,7 +98,8 @@ public interface CodegenConfig extends GlobalCodegenConfig {
         RESTEASY_REACTIVE_CLIENT_FORM("resteasy-reactive-client-form"),
         USE_ONE_OF_INTERFACES("use-one-of-interfaces"),
         IMPLICIT_HEADERS("implicit-headers"),
-        IMPLICIT_HEADERS_REGEX("implicit-headers-regex");
+        IMPLICIT_HEADERS_REGEX("implicit-headers-regex"),
+        REUSE_ENUMS("reuse-enums");
 
         private final String name;
 

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
@@ -247,4 +247,12 @@ public interface CommonItemConfig {
      */
     @WithName("use-one-of-interfaces")
     Optional<Boolean> useOneOfInterfaces();
+
+    /**
+     * When enabled, the generator will reuse top-level enum schemas across different API definitions
+     * whenever they share the same set of allowed values. The first encountered enum schema becomes
+     * the canonical type, and subsequent duplicates are replaced with a {@code $ref} to that schema.
+     */
+    @WithName("reuse-enums")
+    Optional<Boolean> reuseEnums();
 }

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -386,6 +386,9 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
         getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.USE_ONE_OF_INTERFACES, Boolean.class)
                 .ifPresent(generator::withUseOneOfInterfaces);
 
+        getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.REUSE_ENUMS, Boolean.class)
+                .ifPresent(generator::withReuseEnums);
+
         getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.IMPLICIT_HEADERS, Boolean.class)
                 .ifPresent(generator::withImplicitHeaders);
 

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -199,6 +199,11 @@ public abstract class OpenApiClientGeneratorWrapper {
         return this;
     }
 
+    public OpenApiClientGeneratorWrapper withReuseEnums(final Boolean reuseEnums) {
+        this.configurator.addAdditionalProperty("reuse-enums", reuseEnums);
+        return this;
+    }
+
     public OpenApiClientGeneratorWrapper withReturnResponse(String returnResponse) {
         if (returnResponse.equalsIgnoreCase(TRUE.toString())) {
             this.configurator.addAdditionalProperty("return-response", "Response");

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -48,6 +48,7 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
     public static final String QUARKUS_GENERATOR_NAME = "quarkus-generator";
 
     private static final String AUTH_PACKAGE = "auth";
+    private static final String REUSE_ENUMS = "reuse-enums";
     /*
      * Default server URL (the first one in the OpenAPI spec file servers definition.
      */
@@ -226,7 +227,32 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
                 p.setAdditionalProperties(true);
             }
         }
+        if (isReuseEnums() && p != null && p.getEnum() != null && p.get$ref() == null) {
+            String matchedModelName = findMatchingEnumModel(p.getEnum());
+            if (matchedModelName != null) {
+                Schema<?> refSchema = new Schema<>().$ref("#/components/schemas/" + matchedModelName);
+                return super.fromProperty(name, refSchema, required, schemaIsFromAdditionalProperties);
+            }
+        }
         return super.fromProperty(name, p, required, schemaIsFromAdditionalProperties);
+    }
+
+    @Override
+    public String getTypeDeclaration(Schema p) {
+        // Container types (e.g. Set<...>, List<...>) are computed from the raw items schema, which the
+        // parser may present as an inline enum. Without this override the container would be declared
+        // with the enum base type (e.g. String) while fromProperty maps the items to the shared enum model.
+        if (isReuseEnums() && p != null && p.getEnum() != null && p.get$ref() == null) {
+            String matchedModelName = findMatchingEnumModel(p.getEnum());
+            if (matchedModelName != null) {
+                return toModelName(matchedModelName);
+            }
+        }
+        return super.getTypeDeclaration(p);
+    }
+
+    private boolean isReuseEnums() {
+        return Boolean.parseBoolean(String.valueOf(this.additionalProperties.getOrDefault(REUSE_ENUMS, false)));
     }
 
     @Override

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegenTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegenTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.openapi.generator.deployment.wrapper;
 
 import static io.quarkiverse.openapi.generator.deployment.assertions.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -19,6 +20,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
@@ -155,9 +157,56 @@ class QuarkusJavaClientCodegenTest {
         // If it's not a NormalAnnotationExpr, there's definitely no multiSegmentParams attribute
     }
 
+    @Test
+    void verifyInlineEnumReuse() throws URISyntaxException, FileNotFoundException {
+        final List<File> generatedFiles = createGeneratorWrapper("inline-enum-reuse.json", true)
+                .generate("org.enumreuse");
+        assertFalse(generatedFiles.isEmpty());
+
+        final Optional<File> orderFile = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("Order.java")).findFirst();
+        assertThat(orderFile).isPresent();
+
+        final Optional<File> shipmentFile = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("Shipment.java")).findFirst();
+        assertThat(shipmentFile).isPresent();
+
+        final Optional<File> sharedStatusFile = generatedFiles.stream()
+                .filter(f -> f.getName().endsWith("SharedStatus.java")).findFirst();
+        assertThat(sharedStatusFile).isPresent();
+
+        final CompilationUnit orderCu = StaticJavaParser.parse(orderFile.orElseThrow());
+        final CompilationUnit shipmentCu = StaticJavaParser.parse(shipmentFile.orElseThrow());
+
+        assertThat(orderCu.toString()).contains("SharedStatus");
+        assertThat(orderCu.toString()).doesNotContain("StatusEnum");
+
+        assertThat(shipmentCu.toString()).contains("SharedStatus");
+        assertThat(shipmentCu.toString()).doesNotContain("StatusEnum");
+        // container properties must also reuse the shared enum instead of the enum base type
+        assertThat(shipmentCu.toString()).contains("List<SharedStatus>");
+        assertThat(shipmentCu.toString()).doesNotContain("List<String>");
+
+        final CompilationUnit statusCu = StaticJavaParser.parse(sharedStatusFile.orElseThrow());
+        final List<EnumConstantDeclaration> constants = statusCu.findAll(EnumConstantDeclaration.class);
+        assertThat(constants).hasSize(4)
+                .extracting(EnumConstantDeclaration::getNameAsString)
+                .containsExactlyInAnyOrder("CREATED", "PAID", "SHIPPED", "CANCELLED");
+    }
+
     private OpenApiClientGeneratorWrapper createGeneratorWrapper(String specFileName) throws URISyntaxException {
         final Path openApiSpec = getOpenApiSpecPath(specFileName);
-        return new OpenApiClassicClientGeneratorWrapper(openApiSpec, getOpenApiTargetPath(openApiSpec), false, true);
+        OpenApiClientGeneratorWrapper wrapper = new OpenApiClassicClientGeneratorWrapper(openApiSpec,
+                getOpenApiTargetPath(openApiSpec), false, true);
+        return wrapper;
+    }
+
+    private OpenApiClientGeneratorWrapper createGeneratorWrapper(String specFileName, boolean reuseEnums)
+            throws URISyntaxException {
+        final Path openApiSpec = getOpenApiSpecPath(specFileName);
+        OpenApiClientGeneratorWrapper wrapper = new OpenApiClassicClientGeneratorWrapper(openApiSpec,
+                getOpenApiTargetPath(openApiSpec), false, true);
+        return wrapper.withReuseEnums(reuseEnums);
     }
 
     private Path getOpenApiSpecPath(String specFileName) throws URISyntaxException {

--- a/client/deployment/src/test/resources/openapi/inline-enum-reuse.json
+++ b/client/deployment/src/test/resources/openapi/inline-enum-reuse.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Inline Enum Reuse",
+    "version": "1.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["created", "paid", "shipped", "cancelled"]
+          }
+        }
+      },
+      "Shipment": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["created", "paid", "shipped", "cancelled"]
+          },
+          "statusHistory": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["created", "paid", "shipped", "cancelled"]
+            }
+          }
+        }
+      },
+      "SharedStatus": {
+        "type": "string",
+        "enum": ["created", "paid", "shipped", "cancelled"]
+      }
+    }
+  }
+}

--- a/client/integration-tests/reuse-enums/src/main/openapi/openapi.json
+++ b/client/integration-tests/reuse-enums/src/main/openapi/openapi.json
@@ -14,6 +14,32 @@
           "ocpp_integrator"
         ]
       },
+      "UserRoleAssignment": {
+        "type": "object",
+        "required": [
+          "userId",
+          "role"
+        ],
+        "properties": {
+          "userId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "User identifier"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "admin",
+              "operator",
+              "user",
+              "proxy",
+              "shareholder",
+              "ocpp_integrator"
+            ]
+          }
+        }
+      },
       "MeterUserRolesResponse": {
         "type": "object",
         "required": [
@@ -126,6 +152,39 @@
           },
           "404": {
             "description": "Group does not exist"
+          }
+        }
+      }
+    },
+    "/internal/user/{userId}/role-assignment": {
+      "get": {
+        "summary": "Get the role assignment of the given user",
+        "description": "Returns the role assigned to the user. The role property is declared as an inline enum whose values match the top-level MeterUserRole schema.",
+        "operationId": "internalUserUserIdRoleAssignmentGet",
+        "tags": [
+          "User management"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRoleAssignment"
+                }
+              }
+            }
           }
         }
       }

--- a/client/integration-tests/reuse-enums/src/main/resources/application.properties
+++ b/client/integration-tests/reuse-enums/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.openapi-generator.codegen.spec.openapi_json.mutiny=true
+quarkus.openapi-generator.codegen.spec.openapi_json.reuse-enums=true
 quarkus.rest-client.openapi_json.url=http://localhost:8080
 
 quarkus.keycloak.devservices.enabled=false

--- a/client/integration-tests/reuse-enums/src/test/java/io/quarkiverse/openapi/generator/it/ReuseEnumsTest.java
+++ b/client/integration-tests/reuse-enums/src/test/java/io/quarkiverse/openapi/generator/it/ReuseEnumsTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.openapi.generator.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import jakarta.inject.Inject;
@@ -10,6 +11,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.openapi.quarkus.openapi_json.api.UserManagementApi;
 import org.openapi.quarkus.openapi_json.model.MeterUserRole;
+import org.openapi.quarkus.openapi_json.model.UserRoleAssignment;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
@@ -35,5 +37,19 @@ class ReuseEnumsTest {
         // This line will fail to compile if the return type is not properly resolved to Uni<Set<MeterUserRole>>
         Uni<Set<MeterUserRole>> result = api.internalUserUserIdMeterRolesEvaluateMeterMeterIdWildcardGet(1L, 1L);
         assertThat(result).isNotNull();
+    }
+
+    @Test
+    void verifyInlineEnumPropertyReusesTopLevelEnum() {
+        // The role property is declared as an inline enum in the spec. With reuse-enums enabled,
+        // it must be generated as the shared top-level MeterUserRole type instead of a nested enum.
+        // This line will fail to compile if the property type is a nested RoleEnum
+        UserRoleAssignment assignment = new UserRoleAssignment();
+        assignment.setRole(MeterUserRole.ADMIN);
+        MeterUserRole role = assignment.getRole();
+        assertThat(role).isEqualTo(MeterUserRole.ADMIN);
+
+        // No nested enum type should have been generated for the inline enum property
+        assertThat(Arrays.stream(UserRoleAssignment.class.getDeclaredClasses()).anyMatch(Class::isEnum)).isFalse();
     }
 }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

I added `reuse-enums` to consolidate duplicate enums into a single top-level type.
Previously, there were only API returns; the implementation now extends to model properties. I believe this does not alter the previous behavior.

Closes: #551
Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
