### PR TITLE
feat: support for generating a single API class with single-api-name option

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CodegenConfig.java
@@ -72,6 +72,7 @@ public interface CodegenConfig extends GlobalCodegenConfig {
         IMPORT_MAPPINGS("import-mappings"),
         SCHEMA_MAPPINGS("schema-mappings"),
         NORMALIZER("open-api-normalizer"),
+        SINGLE_API_NAME("single-api-name"),
         RETURN_RESPONSE("return-response"),
         ENABLE_SECURITY_GENERATION("enable-security-generation"),
         CONFIG_KEY("config-key"),

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/CommonItemConfig.java
@@ -87,6 +87,16 @@ public interface CommonItemConfig {
     Map<String, String> normalizer();
 
     /**
+     * When set, all operations are generated in a single API class, regardless of the tags declared in the
+     * specification. The value is used verbatim as the name of the generated class, so it must be a valid Java
+     * class name, and `api-name-prefix`/`api-name-suffix` are not applied to it. For example, setting this to
+     * `MyService` generates a single `MyService` class. Equivalent to the OpenAPI Normalizer rule
+     * `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set, this option takes precedence.
+     */
+    @WithName("single-api-name")
+    Optional<String> singleApiName();
+
+    /**
      * Enable SmallRye Mutiny support. If you set this to {@code true}, all return types will be wrapped in
      * {@link io.smallrye.mutiny.Uni}.
      */

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -383,6 +383,9 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
         getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.NORMALIZER, String.class, String.class)
                 .ifPresent(generator::withOpenApiNormalizer);
 
+        getValues(config, openApiFilePath, CodegenConfig.ConfigName.SINGLE_API_NAME, String.class)
+                .ifPresent(generator::withSingleApiName);
+
         getValues(smallRyeConfig, openApiFilePath, CodegenConfig.ConfigName.USE_ONE_OF_INTERFACES, Boolean.class)
                 .ifPresent(generator::withUseOneOfInterfaces);
 

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapper.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.lang.model.SourceVersion;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.openapitools.codegen.CodegenConstants;
@@ -235,6 +237,26 @@ public abstract class OpenApiClientGeneratorWrapper {
 
     public OpenApiClientGeneratorWrapper withOpenApiNormalizer(final Map<String, String> openApiNormalizer) {
         configurator.setOpenapiNormalizer(openApiNormalizer);
+        return this;
+    }
+
+    /**
+     * Generates all operations in a single API class named exactly after the given value.
+     * Must be called after {@link #withOpenApiNormalizer(Map)}, which replaces the whole normalizer rule set.
+     *
+     * @param singleApiName the name of the generated API class; must be a valid Java class name
+     * @return this wrapper
+     * @throws IllegalArgumentException if the given value is not a valid Java class name
+     */
+    public OpenApiClientGeneratorWrapper withSingleApiName(final String singleApiName) {
+        if (singleApiName == null || !SourceVersion.isIdentifier(singleApiName)
+                || SourceVersion.isKeyword(singleApiName)) {
+            throw new IllegalArgumentException(
+                    "Invalid 'single-api-name' value '" + singleApiName
+                            + "'. The value must be a valid Java class name.");
+        }
+        configurator.addOpenapiNormalizer("SET_TAGS_FOR_ALL_OPERATIONS", singleApiName);
+        configurator.addAdditionalProperty(QuarkusJavaClientCodegen.SINGLE_API_NAME, singleApiName);
         return this;
     }
 

--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/wrapper/QuarkusJavaClientCodegen.java
@@ -47,6 +47,8 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
 
     public static final String QUARKUS_GENERATOR_NAME = "quarkus-generator";
 
+    public static final String SINGLE_API_NAME = "single-api-name";
+
     private static final String AUTH_PACKAGE = "auth";
     /*
      * Default server URL (the first one in the OpenAPI spec file servers definition.
@@ -65,6 +67,20 @@ public class QuarkusJavaClientCodegen extends JavaClientCodegen {
     @Override
     public String getName() {
         return "quarkus";
+    }
+
+    /**
+     * When {@code single-api-name} is set, the configured value is used verbatim as the API class name,
+     * ignoring {@code api-name-prefix}/{@code api-name-suffix}. Also affects the file name, since
+     * {@code toApiFilename} delegates to this method.
+     */
+    @Override
+    public String toApiName(String name) {
+        final Object singleApiName = this.additionalProperties.get(SINGLE_API_NAME);
+        if (singleApiName != null && !singleApiName.toString().isBlank()) {
+            return singleApiName.toString();
+        }
+        return super.toApiName(name);
     }
 
     @Override

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/wrapper/OpenApiClientGeneratorWrapperTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.openapi.generator.deployment.wrapper;
 
 import static io.quarkiverse.openapi.generator.deployment.assertions.Assertions.assertThat;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -811,6 +812,41 @@ public class OpenApiClientGeneratorWrapperTest {
         assertThat(types).hasSize(2);
         assertThat(types.get(0).getExtendedTypes()).hasSize(1);
         assertThat(types.get(0).getExtendedTypes(0).getName()).isEqualTo(new SimpleName("Mammal"));
+    }
+
+    @Test
+    void verifySingleApiName() throws Exception {
+        final List<File> generatedFiles = this.createGeneratorWrapper("petstore-openapi.json")
+                .withSingleApiName("PetStore")
+                .generate("org.acme.single");
+
+        // the configured value is used verbatim as the class name, without the `Api` suffix
+        assertThat(generatedFiles).extracting(File::getName).noneMatch(name -> name.endsWith("Api.java"));
+
+        final List<File> apiFiles = generatedFiles.stream()
+                .filter(f -> f.getName().equals("PetStore.java"))
+                .toList();
+        assertThat(apiFiles).hasSize(1);
+
+        final CompilationUnit compilationUnit = StaticJavaParser.parse(apiFiles.get(0));
+        final List<ClassOrInterfaceDeclaration> types = compilationUnit.findAll(ClassOrInterfaceDeclaration.class);
+        assertThat(types).extracting(t -> t.getName().getIdentifier()).containsExactly("PetStore");
+
+        final List<String> methodNames = compilationUnit.findAll(MethodDeclaration.class).stream()
+                .map(MethodDeclaration::getNameAsString)
+                .toList();
+        // operations originally spread across the pet, store and user tags
+        assertThat(methodNames).contains("findPetsByStatus", "getOrderById", "getUserByName");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "My-Service", "123Service", "class", "My Service", "my.Service", "" })
+    void verifySingleApiNameRejectsInvalidJavaClassName(String invalidName) throws Exception {
+        final OpenApiClientGeneratorWrapper wrapper = this.createGeneratorWrapper("petstore-openapi.json");
+        assertThatThrownBy(() -> wrapper.withSingleApiName(invalidName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("single-api-name")
+                .hasMessageContaining("valid Java class name");
     }
 
     @Test

--- a/client/integration-tests/pom.xml
+++ b/client/integration-tests/pom.xml
@@ -45,6 +45,7 @@
     <module>remove-operationid-prefix</module>
     <module>security</module>
     <module>simple</module>
+    <module>single-api</module>
     <module>skip-validation</module>
     <module>suffix-prefix</module>
     <module>type-mapping</module>

--- a/client/integration-tests/single-api/pom.xml
+++ b/client/integration-tests/single-api/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-openapi-generator-integration-tests</artifactId>
+        <groupId>io.quarkiverse.openapi.generator</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-openapi-generator-it-single-api</artifactId>
+    <name>Quarkus - OpenAPI Generator - Integration Tests - Client - Single API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.openapi.generator</groupId>
+            <artifactId>quarkus-openapi-generator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager
+                                        </java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/client/integration-tests/single-api/src/main/openapi/single-api.json
+++ b/client/integration-tests/single-api/src/main/openapi/single-api.json
@@ -1,0 +1,216 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Order Management API",
+    "description": "An e-commerce API with operations spread across multiple tags, used to verify the single-api-name option.",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "orders",
+      "description": "Order management"
+    },
+    {
+      "name": "customers",
+      "description": "Customer management"
+    },
+    {
+      "name": "payments",
+      "description": "Payment processing"
+    }
+  ],
+  "paths": {
+    "/orders": {
+      "post": {
+        "tags": [
+          "orders"
+        ],
+        "operationId": "createOrder",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orders/{orderId}": {
+      "get": {
+        "tags": [
+          "orders"
+        ],
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customers/{customerId}": {
+      "get": {
+        "tags": [
+          "customers"
+        ],
+        "operationId": "getCustomerById",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A customer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments": {
+      "post": {
+        "tags": [
+          "payments"
+        ],
+        "operationId": "processPayment",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Payment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The processed payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customerId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total": {
+            "type": "number",
+            "format": "double"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PLACED",
+              "PAID",
+              "SHIPPED",
+              "DELIVERED"
+            ]
+          }
+        }
+      },
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "Payment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "orderId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "CREDIT_CARD",
+              "PIX",
+              "BANK_TRANSFER"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/client/integration-tests/single-api/src/main/resources/application.properties
+++ b/client/integration-tests/single-api/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.openapi-generator.codegen.spec.single_api_json.base-package=org.acme.openapi.shop
+quarkus.openapi-generator.codegen.spec.single_api_json.single-api-name=OrderManagement

--- a/client/integration-tests/single-api/src/test/java/io/quarkiverse/openapi/generator/it/QuarkusSingleApiTest.java
+++ b/client/integration-tests/single-api/src/test/java/io/quarkiverse/openapi/generator/it/QuarkusSingleApiTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.openapi.generator.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+
+import org.acme.openapi.shop.api.OrderManagement;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class QuarkusSingleApiTest {
+
+    @Test
+    void allOperationsAreGeneratedInSingleApiClass() {
+        assertThat(OrderManagement.class.getMethods())
+                .extracting(Method::getName)
+                .contains("createOrder", "getOrderById", "getCustomerById", "processPayment");
+    }
+
+    @Test
+    void apiSuffixIsNotAppendedToTheConfiguredName() {
+        assertThatThrownBy(() -> Class.forName("org.acme.openapi.shop.api.OrderManagementApi"))
+                .isInstanceOf(ClassNotFoundException.class);
+    }
+
+    @Test
+    void perTagApiClassesAreNotGenerated() {
+        assertThatThrownBy(() -> Class.forName("org.acme.openapi.shop.api.OrdersApi"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThatThrownBy(() -> Class.forName("org.acme.openapi.shop.api.CustomersApi"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThatThrownBy(() -> Class.forName("org.acme.openapi.shop.api.PaymentsApi"))
+                .isInstanceOf(ClassNotFoundException.class);
+    }
+}

--- a/docs/modules/ROOT/pages/client.adoc
+++ b/docs/modules/ROOT/pages/client.adoc
@@ -210,6 +210,11 @@ include::./includes/preferred-content-type.adoc[leveloffset=+1, opts=optional]
 
 include::./includes/generate-apis.adoc[leveloffset=+1, opts=optional]
 
+[[single-api-name]]
+== Generate a single API class
+
+include::./includes/single-api-name.adoc[leveloffset=+1, opts=optional]
+
 [[generate-models]]
 == Generate Models
 

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
@@ -238,6 +238,27 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-single-api-name]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-single-api-name[`+++quarkus.openapi-generator.codegen.single-api-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.single-api-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set, all operations are generated in a single API class, regardless of the tags declared in the specification. The value is used verbatim as the name of the generated class, so it must be a valid Java class name, and `api-name-prefix`/`api-name-suffix` are not applied to it. For example, setting this to `MyService` generates a single `MyService` class. Equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set, this option takes precedence.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SINGLE_API_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SINGLE_API_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny[`+++quarkus.openapi-generator.codegen.mutiny+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi-generator.codegen.mutiny+++[]
@@ -1108,6 +1129,27 @@ Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__OPE
 endif::add-copy-button-to-env-var[]
 --
 |Map<String,String>
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-single-api-name]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-single-api-name[`+++quarkus.openapi-generator.codegen.spec."spec-item".single-api-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.spec."spec-item".single-api-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set, all operations are generated in a single API class, regardless of the tags declared in the specification. The value is used verbatim as the name of the generated class, so it must be a valid Java class name, and `api-name-prefix`/`api-name-suffix` are not applied to it. For example, setting this to `MyService` generates a single `MyService` class. Equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set, this option takes precedence.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__SINGLE_API_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__SINGLE_API_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny[`+++quarkus.openapi-generator.codegen.spec."spec-item".mutiny+++`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
@@ -238,6 +238,27 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-single-api-name]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-single-api-name[`+++quarkus.openapi-generator.codegen.single-api-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.single-api-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set, all operations are generated in a single API class, regardless of the tags declared in the specification. The value is used verbatim as the name of the generated class, so it must be a valid Java class name, and `api-name-prefix`/`api-name-suffix` are not applied to it. For example, setting this to `MyService` generates a single `MyService` class. Equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set, this option takes precedence.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SINGLE_API_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SINGLE_API_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-mutiny[`+++quarkus.openapi-generator.codegen.mutiny+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.openapi-generator.codegen.mutiny+++[]
@@ -1108,6 +1129,27 @@ Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__OPE
 endif::add-copy-button-to-env-var[]
 --
 |Map<String,String>
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-single-api-name]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-single-api-name[`+++quarkus.openapi-generator.codegen.spec."spec-item".single-api-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator.codegen.spec."spec-item".single-api-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set, all operations are generated in a single API class, regardless of the tags declared in the specification. The value is used verbatim as the name of the generated class, so it must be a valid Java class name, and `api-name-prefix`/`api-name-suffix` are not applied to it. For example, setting this to `MyService` generates a single `MyService` class. Equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set, this option takes precedence.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__SINGLE_API_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR_CODEGEN_SPEC__SPEC_ITEM__SINGLE_API_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-codegen-spec-spec-item-mutiny[`+++quarkus.openapi-generator.codegen.spec."spec-item".mutiny+++`]##

--- a/docs/modules/ROOT/pages/includes/single-api-name.adoc
+++ b/docs/modules/ROOT/pages/includes/single-api-name.adoc
@@ -1,0 +1,14 @@
+By default, one API class is generated per tag defined in the OpenAPI specification. If you prefer to have all
+operations generated in a single API class, regardless of the tags, set `single-api-name` to the desired name:
+
+[source,properties]
+----
+quarkus.openapi-generator.codegen.spec.my_openapi_yaml.single-api-name=MyService
+----
+
+The value is used verbatim as the name of the generated class, so the example above generates a single `MyService`
+class containing all the operations in the specification. Because of that, the value must be a valid Java class
+name (the build fails otherwise), and `api-name-prefix`/`api-name-suffix` are not applied to it.
+
+This option is equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are set,
+`single-api-name` takes precedence.


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

Closes : #360 

By default, the generator creates one API class per tag defined in the OpenAPI specification. This PR adds a new per-spec configuration property, `single-api-name`, that lets users generate all operations into a single API class, regardless of the tags declared in the spec file:

```properties
quarkus.openapi-generator.codegen.spec.my_openapi_yaml.single-api-name=MyService
```

The value is applied as the tag for every operation, so the example above produces a single `MyServiceApi` class containing all operations (the `Api` suffix can still be customized with `api-name-suffix`). This is equivalent to the OpenAPI Normalizer rule `SET_TAGS_FOR_ALL_OPERATIONS`; if both are configured, `single-api-name` takes precedence.

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [X] Pull Request contains link to the issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
