### PR TITLE
fix: add exclusive-auth flag to control OR vs AND security semantics

### DIFF
--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
@@ -2,6 +2,9 @@ package io.quarkiverse.openapi.generator;
 
 import java.util.Optional;
 
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 
 /**
@@ -21,6 +24,14 @@ public interface SpecItemConfig {
      * @see AuthsConfig
      */
     AuthsConfig auth();
+
+    /**
+     * When set to true, only the first successful authentication provider is applied per request (OR semantics).
+     * When false (default), all matching authentication providers are applied (AND semantics).
+     */
+    @WithName("exclusive-auth")
+    @WithDefault("false")
+    boolean exclusiveAuth();
 
     default Optional<AuthsConfig> getAuth() {
         return Optional.ofNullable(auth());

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/SpecItemConfig.java
@@ -2,10 +2,9 @@ package io.quarkiverse.openapi.generator;
 
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
-
-import io.quarkus.runtime.annotations.ConfigGroup;
 
 /**
  * This class represents the runtime authentication related configurations for the individual OpenApi spec definitions,

--- a/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
+++ b/client/runtime/src/main/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProvider.java
@@ -46,14 +46,19 @@ public class BaseCompositeAuthenticationProvider implements ClientRequestFilter 
      */
     public static final String OPERATION_ID_PROPERTY = "io.quarkiverse.openapi.generator.operationId";
 
+    static final String EXCLUSIVE_AUTH_CONFIG_PREFIX = "quarkus.openapi-generator.";
+    static final String EXCLUSIVE_AUTH_CONFIG_SUFFIX = ".exclusive-auth";
+
     private final List<AuthProvider> authProviders;
     private final String openApiSpecId;
     private final String baseUrlPath;
+    private final boolean exclusiveAuth;
 
     public BaseCompositeAuthenticationProvider(String openApiSpecId, List<AuthProvider> authProviders) {
         this.openApiSpecId = openApiSpecId;
         this.authProviders = List.copyOf(authProviders);
         this.baseUrlPath = resolveBaseUrlPath();
+        this.exclusiveAuth = resolveExclusiveAuth();
     }
 
     public BaseCompositeAuthenticationProvider(List<AuthProvider> authProviders) {
@@ -79,9 +84,12 @@ public class BaseCompositeAuthenticationProvider implements ClientRequestFilter 
                 Optional<Exception> possibleException = tryFilter(authProvider, requestContext);
                 if (possibleException.isEmpty()) {
                     applied = true;
-                    break;
+                    if (exclusiveAuth) {
+                        break;
+                    }
+                } else {
+                    exceptionsDuringFilter.add(possibleException.get());
                 }
-                exceptionsDuringFilter.add(possibleException.get());
             }
         }
 
@@ -94,12 +102,10 @@ public class BaseCompositeAuthenticationProvider implements ClientRequestFilter 
 
     /**
      * Tries to apply the filter of the given provider.
-     * As per the OpenAPI spec, only one security requirement needs to be satisfied.
-     * See <a href="https://spec.openapis.org/oas/v3.1.0#security-requirement-object">Security Requirement Object</a>:
-     * "A declaration of security schemes which can be used for the API operation.
-     * The list of values includes alternative security requirement objects that can be used.
-     * Only one of the security requirement objects need to be satisfied to authorize a request."
-     * Thus, if one provider successfully applied, we stop trying others for this request.
+     * By default, all matching providers are applied (AND semantics). When {@code exclusive-auth}
+     * is enabled, only the first successful provider is applied (OR semantics).
+     * If a provider fails, the exception is collected and iteration continues.
+     * If at least one provider succeeds, no exception is thrown.
      *
      * @return an empty {@link Optional} if the filter was applied successfully,
      *         or an {@link Optional} containing the exception if the provider failed.
@@ -169,8 +175,21 @@ public class BaseCompositeAuthenticationProvider implements ClientRequestFilter 
      * {@code quarkus.rest-client.<openApiSpecId>.url}.
      * Returns null if the openApiSpecId is not set or the URL cannot be resolved.
      */
+    boolean isExclusiveAuth() {
+        return exclusiveAuth;
+    }
+
     String getBaseUrlPath() {
         return baseUrlPath;
+    }
+
+    private boolean resolveExclusiveAuth() {
+        if (openApiSpecId == null) {
+            return false;
+        }
+        return ConfigProvider.getConfig()
+                .getOptionalValue(EXCLUSIVE_AUTH_CONFIG_PREFIX + openApiSpecId + EXCLUSIVE_AUTH_CONFIG_SUFFIX, Boolean.class)
+                .orElse(false);
     }
 
     private String resolveBaseUrlPath() {

--- a/client/runtime/src/test/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProviderTest.java
+++ b/client/runtime/src/test/java/io/quarkiverse/openapi/generator/providers/BaseCompositeAuthenticationProviderTest.java
@@ -114,6 +114,11 @@ class BaseCompositeAuthenticationProviderTest {
 
     private BaseCompositeAuthenticationProvider createProviderWithConfig(String specId, Optional<String> urlValue,
             List<AuthProvider> authProviders) {
+        return createProviderWithConfig(specId, urlValue, Optional.empty(), authProviders);
+    }
+
+    private BaseCompositeAuthenticationProvider createProviderWithConfig(String specId, Optional<String> urlValue,
+            Optional<Boolean> exclusiveAuth, List<AuthProvider> authProviders) {
         try (MockedStatic<ConfigProvider> configMock = mockStatic(ConfigProvider.class)) {
             Config config = mock(Config.class);
             configMock.when(ConfigProvider::getConfig).thenReturn(config);
@@ -122,12 +127,17 @@ class BaseCompositeAuthenticationProviderTest {
                             + BaseCompositeAuthenticationProvider.REST_CLIENT_URL_CONFIG_SUFFIX,
                     String.class))
                     .thenReturn(urlValue);
+            when(config.getOptionalValue(
+                    BaseCompositeAuthenticationProvider.EXCLUSIVE_AUTH_CONFIG_PREFIX + specId
+                            + BaseCompositeAuthenticationProvider.EXCLUSIVE_AUTH_CONFIG_SUFFIX,
+                    Boolean.class))
+                    .thenReturn(exclusiveAuth);
             return new BaseCompositeAuthenticationProvider(specId, authProviders);
         }
     }
 
     private BaseCompositeAuthenticationProvider createProviderWithConfig(String specId, Optional<String> urlValue) {
-        return createProviderWithConfig(specId, urlValue, List.of());
+        return createProviderWithConfig(specId, urlValue, Optional.empty(), List.of());
     }
 
     private void withConfigMockThrows(String specId, Optional<String> urlValue, ThrowingRunnable action) throws IOException {
@@ -139,6 +149,11 @@ class BaseCompositeAuthenticationProviderTest {
                             + BaseCompositeAuthenticationProvider.REST_CLIENT_URL_CONFIG_SUFFIX,
                     String.class))
                     .thenReturn(urlValue);
+            lenient().when(config.getOptionalValue(
+                    BaseCompositeAuthenticationProvider.EXCLUSIVE_AUTH_CONFIG_PREFIX + specId
+                            + BaseCompositeAuthenticationProvider.EXCLUSIVE_AUTH_CONFIG_SUFFIX,
+                    Boolean.class))
+                    .thenReturn(Optional.empty());
             action.run();
         }
     }
@@ -161,13 +176,13 @@ class BaseCompositeAuthenticationProviderTest {
     //region Alternative security scheme tests
 
     @Test
-    void testOnlyOneAlternativeProviderIsCalled() throws IOException {
+    void testAllMatchingProvidersAreCalled() throws IOException {
         AuthProvider provider1 = Mockito.mock(AuthProvider.class);
         AuthProvider provider2 = Mockito.mock(AuthProvider.class);
 
         OperationAuthInfo operation = createOperation();
         when(provider1.operationsToFilter()).thenReturn(List.of(operation));
-        lenient().when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
 
         ClientRequestContext requestContext = createRequestContext("POST", "/api/test", "testOp");
         MultivaluedMap<String, Object> headers = requestContext.getHeaders();
@@ -179,7 +194,7 @@ class BaseCompositeAuthenticationProviderTest {
         composite.filter(requestContext);
 
         verify(provider1, times(1)).filter(any(ClientRequestContext.class));
-        verify(provider2, never()).filter(any(ClientRequestContext.class));
+        verify(provider2, times(1)).filter(any(ClientRequestContext.class));
         assertEquals("Bearer token1", headers.getFirst("Authorization"));
     }
 
@@ -232,15 +247,15 @@ class BaseCompositeAuthenticationProviderTest {
     }
 
     @Test
-    void testStopsOnFirstSuccessfulProvider() throws IOException {
+    void testAllMatchingProvidersAreCalledInOrder() throws IOException {
         AuthProvider provider1 = Mockito.mock(AuthProvider.class);
         AuthProvider provider2 = Mockito.mock(AuthProvider.class);
         AuthProvider provider3 = Mockito.mock(AuthProvider.class);
 
         OperationAuthInfo operation = createOperation();
         when(provider1.operationsToFilter()).thenReturn(List.of(operation));
-        lenient().when(provider2.operationsToFilter()).thenReturn(List.of(operation));
-        lenient().when(provider3.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider3.operationsToFilter()).thenReturn(List.of(operation));
 
         ClientRequestContext requestContext = createRequestContext("POST", "/api/test", "testOp");
         MultivaluedMap<String, Object> headers = requestContext.getHeaders();
@@ -253,8 +268,8 @@ class BaseCompositeAuthenticationProviderTest {
         composite.filter(requestContext);
 
         verify(provider1, times(1)).filter(any(ClientRequestContext.class));
-        verify(provider2, never()).filter(any(ClientRequestContext.class));
-        verify(provider3, never()).filter(any(ClientRequestContext.class));
+        verify(provider2, times(1)).filter(any(ClientRequestContext.class));
+        verify(provider3, times(1)).filter(any(ClientRequestContext.class));
         assertEquals("Bearer token1", headers.getFirst("Authorization"));
     }
 
@@ -293,6 +308,59 @@ class BaseCompositeAuthenticationProviderTest {
         BaseCompositeAuthenticationProvider composite = new BaseCompositeAuthenticationProvider(List.of(provider));
 
         assertFilterThrows(composite, requestContext, "Network error");
+    }
+
+    //endregion
+
+    //region Exclusive auth tests (OR semantics)
+
+    @Test
+    void testExclusiveAuthStopsOnFirstSuccess() throws IOException {
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        lenient().when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test", "testOp");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        givenProviderWillAuthenticate(provider1, headers, "Bearer token1");
+
+        BaseCompositeAuthenticationProvider composite = createProviderWithConfig(
+                "my_spec_yaml", Optional.empty(), Optional.of(true), List.of(provider1, provider2));
+
+        composite.filter(requestContext);
+
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+        verify(provider2, never()).filter(any(ClientRequestContext.class));
+        assertEquals("Bearer token1", headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void testExclusiveAuthFallsBackOnFailure() throws IOException {
+        AuthProvider provider1 = Mockito.mock(AuthProvider.class);
+        AuthProvider provider2 = Mockito.mock(AuthProvider.class);
+
+        OperationAuthInfo operation = createOperation();
+        when(provider1.operationsToFilter()).thenReturn(List.of(operation));
+        when(provider2.operationsToFilter()).thenReturn(List.of(operation));
+
+        ClientRequestContext requestContext = createRequestContext("POST", "/api/test", "testOp");
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+
+        givenProviderWillFail(provider1, new RuntimeException("Missing OAuth2 configuration"));
+        givenProviderWillAuthenticate(provider2, headers, "Bearer token2");
+
+        BaseCompositeAuthenticationProvider composite = createProviderWithConfig(
+                "my_spec_yaml", Optional.empty(), Optional.of(true), List.of(provider1, provider2));
+
+        composite.filter(requestContext);
+
+        verify(provider1, times(1)).filter(any(ClientRequestContext.class));
+        verify(provider2, times(1)).filter(any(ClientRequestContext.class));
+        assertEquals("Bearer token2", headers.getFirst("Authorization"));
     }
 
     //endregion

--- a/docs/modules/ROOT/pages/includes/authentication-support.adoc
+++ b/docs/modules/ROOT/pages/includes/authentication-support.adoc
@@ -46,6 +46,23 @@ If the OpenAPI specification file has `securitySchemes` definitions, but no http
 
 See the module https://github.com/quarkiverse/quarkus-openapi-generator/tree/main/client/integration-tests/security[security] for an example of how to use this feature.
 
+== Multiple Security Schemes
+
+When an OpenAPI operation references multiple security schemes, the extension applies *all* matching authentication providers by default. This means every configured scheme (API key, Basic, Bearer, OAuth2) will add its credentials to the request.
+
+If your specification uses security schemes as *alternatives* (only one needs to succeed), you can enable exclusive authentication mode. In this mode, the extension stops after the first provider that successfully authenticates, skipping the rest. If the first provider fails (e.g., missing OAuth2 configuration), it falls back to the next one.
+
+[%autowidth]
+|===
+|Description |Property Key |Example
+
+|Enable exclusive (OR) authentication
+|`quarkus.openapi-generator.[filename].exclusive-auth`
+|`quarkus.openapi-generator.petstore_json.exclusive-auth=true`
+|===
+
+NOTE: The https://spec.openapis.org/oas/v3.1.0#security-requirement-object[OpenAPI specification] distinguishes between alternative security requirements (OR) and conjunctive requirements (AND). However, the upstream code generator flattens both into a single list, so the extension cannot automatically determine the intended semantics. Use this flag to select the behavior that matches your API's requirements.
+
 == Basic HTTP Authentication
 
 For Basic HTTP Authentication, these are the supported configurations:

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator.adoc
@@ -1914,5 +1914,26 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a| [[quarkus-openapi-generator_quarkus-openapi-generator-item-configs-exclusive-auth]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-item-configs-exclusive-auth[`+++quarkus.openapi-generator."item-configs".exclusive-auth+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator."item-configs".exclusive-auth+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set to true, only the first successful authentication provider is applied per request (OR semantics). When false (default), all matching authentication providers are applied (AND semantics).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR__ITEM_CONFIGS__EXCLUSIVE_AUTH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR__ITEM_CONFIGS__EXCLUSIVE_AUTH+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-openapi-generator_quarkus.openapi-generator.adoc
@@ -1914,5 +1914,26 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a| [[quarkus-openapi-generator_quarkus-openapi-generator-item-configs-exclusive-auth]] [.property-path]##link:#quarkus-openapi-generator_quarkus-openapi-generator-item-configs-exclusive-auth[`+++quarkus.openapi-generator."item-configs".exclusive-auth+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.openapi-generator."item-configs".exclusive-auth+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When set to true, only the first successful authentication provider is applied per request (OR semantics). When false (default), all matching authentication providers are applied (AND semantics).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPENAPI_GENERATOR__ITEM_CONFIGS__EXCLUSIVE_AUTH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPENAPI_GENERATOR__ITEM_CONFIGS__EXCLUSIVE_AUTH+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 


### PR DESCRIPTION
## Summary

Fixes #1741

- Adds a per-spec `exclusive-auth` config flag to `BaseCompositeAuthenticationProvider` that controls whether auth providers are treated as alternatives (OR) or applied together (AND)
- Default is `false` (AND — apply all matching providers), restoring pre-2.20.0 behavior
- When `true`, stops after the first successful provider (OR — the 2.20.0+ behavior)

The upstream `openapi-generator` library flattens AND/OR security requirement groups into a single `List<CodegenSecurity>`, making it impossible to distinguish them at code generation time. This flag gives users control at runtime.

### Config

```properties
# Default: apply all auth providers (AND semantics)
quarkus.openapi-generator.my_spec_yaml.exclusive-auth=false

# Stop after first successful provider (OR semantics)
quarkus.openapi-generator.my_spec_yaml.exclusive-auth=true
```

### Files changed

- `SpecItemConfig.java` — new `exclusive-auth` boolean property
- `BaseCompositeAuthenticationProvider.java` — reads flag, conditionally breaks after first success
- `BaseCompositeAuthenticationProviderTest.java` — 2 existing tests updated for AND default, 2 new tests for exclusive-auth mode
- `authentication-support.adoc` — new "Multiple Security Schemes" documentation section
- Auto-generated config reference docs updated

## Test plan

- [x] All 98 runtime unit tests pass (including 16 `BaseCompositeAuthenticationProviderTest`)
- [x] Verified with [kogito-runtimes](https://github.com/kiegroup/kogito-runtimes) integration tests (`ApiWithSecurityContextIT` — 4/4 pass)