### PR TITLE
Upgrade and centralize OpenAPITools (7.24.0)

### DIFF
--- a/client/deployment/pom.xml
+++ b/client/deployment/pom.xml
@@ -11,7 +11,6 @@
   <name>Quarkus - OpenAPI Generator - Client - Deployment</name>
 
   <properties>
-    <version.org.openapitools>7.23.0</version.org.openapitools>
     <version.org.slf4j>2.0.18</version.org.slf4j>
     <version.com.github.jknack>4.3.1</version.com.github.jknack>
   </properties>

--- a/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
+++ b/client/deployment/src/main/resources/templates/libraries/microprofile/pojo.qute
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 {/if}
 {#include suppressWarnings.qute/}
-{#if m.vendorExtensions.containsKey('x-class-extra-annotation')}
-{m.vendorExtensions['x-class-extra-annotation']}
-{/if}
+{#for ext in m.vendorExtensions.x-class-extra-annotation.orEmpty}
+{ext}
+{/for}
 {#let xImpl=m.vendorExtensions.x-implements.or(false)}public class {m.classname} {#if m.parent}extends {m.parent}{/if}{#if xImpl} implements {#for iface in xImpl}{iface}{#if iface_hasNext}, {/if}{/for}{/if}{/let} {
 
     {#for v in m.vars}

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapterTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/template/QuteTemplatingEngineAdapterTest.java
@@ -2,7 +2,6 @@ package io.quarkiverse.openapi.generator.deployment.template;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
@@ -11,8 +10,6 @@ import java.nio.file.Files;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
 
@@ -41,19 +38,4 @@ public class QuteTemplatingEngineAdapterTest {
         }
     }
 
-    @Test
-    @EnabledOnOs({ OS.WINDOWS })
-    void checkOpenApiSpecIsNotAvailableOnWindows() throws IOException {
-        // On Windows getResource prepends a leading slash which leads to an invalid file path
-        final String petstoreOpenApi = requireNonNull(this.getClass().getResource("/openapi/petstore-openapi.json"))
-                .getPath();
-        final DefaultGenerator generator = new DefaultGenerator();
-        final CodegenConfigurator configurator = new QuarkusCodegenConfigurator();
-        final File apiFile = File.createTempFile("api", ".java");
-        apiFile.deleteOnExit();
-        configurator.setInputSpec(petstoreOpenApi);
-        // skip message evaluation as the NPE doesn't have a message in all scenarios, seems to be JDK dependent
-        assertThrows(NullPointerException.class,
-                () -> generator.opts(configurator.toClientOptInput()));
-    }
 }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

The checkOpenApiSpecIsNotAvailableOnWindows test asserted a bug in
older OpenAPITools where Windows resource paths with a leading slash
caused a NullPointerException. This bug is fixed in 7.24.0, making
the test obsolete.

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ ] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
