### PR TITLE
Prevent duplicate code generation across multiple source roots

### DIFF
--- a/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
+++ b/client/deployment/src/main/java/io/quarkiverse/openapi/generator/deployment/codegen/OpenApiGeneratorCodeGenBase.java
@@ -9,8 +9,6 @@ import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigNa
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.BASE_PACKAGE;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.DEFAULT_SECURITY_SCHEME;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.EXCLUDE;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.IMPLICIT_HEADERS;
-import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.IMPLICIT_HEADERS_REGEX;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.INCLUDE;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.INPUT_BASE_DIR;
 import static io.quarkiverse.openapi.generator.deployment.CodegenConfig.ConfigName.MODEL_NAME_PREFIX;
@@ -98,13 +96,26 @@ public abstract class OpenApiGeneratorCodeGenBase implements CodeGenProvider {
 
     @Override
     public boolean shouldRun(Path sourceDir, Config config) {
+        // Only run for the main source directory to prevent multiple executions
+        // when the project has multiple source roots (e.g. src/main and src/test),
+        // which would otherwise generate duplicate classes when input-base-dir is set,
+        // since the resolved directory does not depend on which source root triggered it.
+        if (!sourceDir.endsWith(Path.of("src", "main", this.inputDirectory()))) {
+            return isTestSourceDir(sourceDir) && getInputBaseDirRelativeToModule(sourceDir, config).isEmpty()
+                    && Files.isDirectory(sourceDir);
+        }
+
         String inputBaseDir = getInputBaseDirRelativeToModule(sourceDir, config).orElse(null);
 
         if (inputBaseDir != null) {
             return Files.isDirectory(Path.of(inputBaseDir));
         } else {
-            return Files.isDirectory(sourceDir) || sourceDir.endsWith(Path.of("src", "test", this.inputDirectory()));
+            return Files.isDirectory(sourceDir);
         }
+    }
+
+    private boolean isTestSourceDir(Path sourceDir) {
+        return sourceDir.endsWith(Path.of("src", "test", this.inputDirectory()));
     }
 
     protected boolean isRestEasyReactive(CodeGenContext context) {

--- a/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/OpenApiGeneratorCodeGenShouldRunTest.java
+++ b/client/deployment/src/test/java/io/quarkiverse/openapi/generator/deployment/OpenApiGeneratorCodeGenShouldRunTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.openapi.generator.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkiverse.openapi.generator.common.OpenApiGeneratorOptions;
+import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiGeneratorCodeGenBase;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+class OpenApiGeneratorCodeGenShouldRunTest {
+
+    @TempDir
+    Path projectDir;
+
+    private final TestCodegen codegen = new TestCodegen();
+
+    @Test
+    void shouldRunForMainOpenApiDirectory() throws IOException {
+        Path sourceDir = createDir("src", "main", "openapi");
+
+        assertThat(codegen.shouldRun(sourceDir, config(Map.of()))).isTrue();
+    }
+
+    @Test
+    void shouldRunForTestOpenApiDirectoryWhenInputBaseDirIsNotSet() throws IOException {
+        Path sourceDir = createDir("src", "test", "openapi");
+
+        assertThat(codegen.shouldRun(sourceDir, config(Map.of()))).isTrue();
+    }
+
+    @Test
+    void shouldNotRunForOtherSourceRoot() throws IOException {
+        Path sourceDir = createDir("target", "generated-sources", "openapi");
+
+        assertThat(codegen.shouldRun(sourceDir, config(Map.of()))).isFalse();
+    }
+
+    @Test
+    void shouldRunOnlyOnceWhenCustomInputBaseDirIsConfigured() throws IOException {
+        createDir("mycustompath");
+
+        Config config = config(Map.of(
+                "quarkus.openapi-generator.codegen.input-base-dir", "mycustompath"));
+
+        Path mainSourceDir = projectDir.resolve("src").resolve("main").resolve("openapi");
+        Path testSourceDir = projectDir.resolve("src").resolve("test").resolve("openapi");
+
+        assertThat(codegen.shouldRun(mainSourceDir, config)).isTrue();
+        assertThat(codegen.shouldRun(testSourceDir, config)).isFalse();
+    }
+
+    private Path createDir(String... parts) throws IOException {
+        Path dir = projectDir;
+        for (String part : parts) {
+            dir = dir.resolve(part);
+        }
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    private static SmallRyeConfig config(Map<String, String> values) {
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+        values.forEach(builder::withDefaultValue);
+        return builder.build();
+    }
+
+    static final class TestCodegen extends OpenApiGeneratorCodeGenBase {
+        @Override
+        protected void doGenerate(OpenApiGeneratorOptions options) {
+        }
+
+        @Override
+        public String providerId() {
+            return "openapi-test";
+        }
+
+        @Override
+        public String[] inputExtensions() {
+            return new String[] { ".yaml" };
+        }
+    }
+}


### PR DESCRIPTION
Restrict shouldRun to the src/main/<inputDirectory> source root so codegen doesn't run again for src/test when input-base-dir is configured, since the resolved directory doesn't depend on which source root triggered it. Adds coverage for shouldRun behavior.

Fixes #1745

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [our code style](CONTRIBUTING.md#code-style)
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Subject`
- [ ] Pull Request contains link to the issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
